### PR TITLE
Remove unrecognised properties from fiscal year sample record MODFUND-37

### DIFF
--- a/sample-data/fiscal-years/fy1.json
+++ b/sample-data/fiscal-years/fy1.json
@@ -2,7 +2,5 @@
   "id":"684b5dc5-92f6-4db7-b996-b549d88f5e4e",
   "name": "FY19",
   "code": "19",
-  "description": "Fiscal Year 2018-2019",
-  "period_start": "2018-07-01T13:06:34.186Z",
-  "period_end": "2019-06-30T13:06:34.186Z"
+  "description": "Fiscal Year 2018-2019"
 }


### PR DESCRIPTION
*Purpose*

To fix the failure of the reference environment builds - see https://issues.folio.org/browse/FOLIO-1500 and https://issues.folio.org/browse/MODFUND-37

*Approach*

Removes the now unrecognised properties from the sample record.

May only be a temporary resolution if the {{period_start}} and {{period_end}} properties were intended to be still included in the schema. If they were intended to be removed, then this is a breaking compatibility change rather than a bug.

*Questions*

Were the properties intended to be removed?