### PR TITLE
MODFIN-110 - Enforce allocatedFromIds and allocatedToIds

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -353,11 +353,7 @@
           "permissionsRequired": ["finance.allocations.item.post"],
           "modulePermissions": [
             "finance-storage.transactions.item.post",
-            "finance-storage.funds.item.get",
-            "finance-storage.ledgers.item.get",
-            "finance-storage.fiscal-years.item.get",
-            "finance-storage.fiscal-years.collection.get",
-            "finance-storage.group-fund-fiscal-years.collection.get"
+            "finance-storage.funds.item.get"
           ]
         },
         {
@@ -374,11 +370,7 @@
           "permissionsRequired": ["finance.transfers.item.post"],
           "modulePermissions": [
             "finance-storage.transactions.item.post",
-            "finance-storage.funds.item.get",
-            "finance-storage.ledgers.item.get",
-            "finance-storage.fiscal-years.item.get",
-            "finance-storage.fiscal-years.collection.get",
-            "finance-storage.group-fund-fiscal-years.collection.get"
+            "finance-storage.funds.item.get"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -352,7 +352,12 @@
           "pathPattern": "/finance/allocations",
           "permissionsRequired": ["finance.allocations.item.post"],
           "modulePermissions": [
-            "finance-storage.transactions.item.post"
+            "finance-storage.transactions.item.post",
+            "finance-storage.funds.item.get",
+            "finance-storage.ledgers.item.get",
+            "finance-storage.fiscal-years.item.get",
+            "finance-storage.fiscal-years.collection.get",
+            "finance-storage.group-fund-fiscal-years.collection.get"
           ]
         },
         {
@@ -368,7 +373,12 @@
           "pathPattern": "/finance/transfers",
           "permissionsRequired": ["finance.transfers.item.post"],
           "modulePermissions": [
-            "finance-storage.transactions.item.post"
+            "finance-storage.transactions.item.post",
+            "finance-storage.funds.item.get",
+            "finance-storage.ledgers.item.get",
+            "finance-storage.fiscal-years.item.get",
+            "finance-storage.fiscal-years.collection.get",
+            "finance-storage.group-fund-fiscal-years.collection.get"
           ]
         },
         {

--- a/src/main/java/org/folio/rest/helper/FundsHelper.java
+++ b/src/main/java/org/folio/rest/helper/FundsHelper.java
@@ -168,7 +168,7 @@ public class FundsHelper extends AbstractHelper {
       .thenCompose(json -> supplyBlockingAsync(ctx, () -> json.mapTo(FundsCollection.class)));
   }
 
-  public CompletableFuture<CompositeFund> getFund(String id) {
+  public CompletableFuture<CompositeFund> getCompositeFund(String id) {
     return handleGetRequest(resourceByIdPath(FUNDS, id, lang))
       .thenApply(json -> new CompositeFund().withFund(json.mapTo(Fund.class)))
       .thenCompose(compositeFund -> getCurrentFiscalYear(compositeFund.getFund()
@@ -176,6 +176,11 @@ public class FundsHelper extends AbstractHelper {
           .thenCompose(currentFY -> Objects.isNull(currentFY) ? CompletableFuture.completedFuture(null)
               : getGroupIdsThatFundBelongs(id, currentFY.getId()))
           .thenApply(compositeFund::withGroupIds));
+  }
+
+  public CompletableFuture<Fund> getFund(String id) {
+    return handleGetRequest(resourceByIdPath(FUNDS, id, lang))
+      .thenApply(json -> json.mapTo(Fund.class));
   }
 
   private CompletableFuture<Void> assignFundToGroups(List<GroupFundFiscalYear> groupFundFiscalYears) {

--- a/src/main/java/org/folio/rest/helper/TransactionRestrictHelper.java
+++ b/src/main/java/org/folio/rest/helper/TransactionRestrictHelper.java
@@ -1,0 +1,64 @@
+package org.folio.rest.helper;
+
+import static org.folio.rest.util.ErrorCodes.ALLOCATION_IDS_MISMATCH;
+import static org.folio.rest.util.ErrorCodes.MISSING_FUND_ID;
+
+import io.vertx.core.Context;
+import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.folio.rest.exception.HttpException;
+import org.folio.rest.jaxrs.model.Transaction;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+public class TransactionRestrictHelper extends AbstractHelper {
+
+  public TransactionRestrictHelper(Map<String, String> okapiHeaders, Context ctx, String lang) {
+    super(okapiHeaders, ctx, lang);
+  }
+
+  public CompletableFuture<Transaction> checkRestrictions(Transaction transaction) {
+    switch (transaction.getTransactionType()) {
+      case ALLOCATION:
+        return checkAllocation(transaction);
+      case TRANSFER:
+        return checkTransfer(transaction);
+      default:
+        return CompletableFuture.completedFuture(transaction);
+    }
+  }
+
+  private CompletableFuture<Transaction> checkAllocation(Transaction transaction) {
+    if (Objects.isNull(transaction.getFromFundId()) ^ Objects.isNull(transaction.getToFundId())) {
+      return CompletableFuture.completedFuture(transaction);
+    } else {
+      return checkFundsAllocatedIds(transaction);
+    }
+  }
+
+  private CompletableFuture<Transaction> checkTransfer(Transaction transaction) {
+    return checkFundsAllocatedIds(transaction);
+  }
+
+  private CompletableFuture<Transaction> checkFundsAllocatedIds(Transaction transaction) {
+    CompletableFuture<Transaction> future = new VertxCompletableFuture<>(ctx);
+    if (Objects.nonNull(transaction.getFromFundId()) && Objects.nonNull(transaction.getToFundId())) {
+      FundsHelper fundsHelper = new FundsHelper(okapiHeaders, ctx, lang);
+      return fundsHelper.getFund(transaction.getFromFundId())
+        .thenCombine(fundsHelper.getFund(transaction.getToFundId()), (fromFund, toFund) ->
+          (fromFund.getAllocatedToIds().isEmpty() || fromFund.getAllocatedToIds().contains(transaction.getToFundId())) &&
+            (toFund.getAllocatedFromIds().isEmpty() || toFund.getAllocatedFromIds().contains(transaction.getFromFundId())))
+        .thenApply(isMatch -> {
+          if (Boolean.TRUE.equals(isMatch)) {
+            return transaction;
+          } else {
+            throw new HttpException(422, ALLOCATION_IDS_MISMATCH);
+          }
+        });
+    } else {
+      future.completeExceptionally(new HttpException(422, MISSING_FUND_ID));
+    }
+    return future;
+  }
+}

--- a/src/main/java/org/folio/rest/helper/TransactionsHelper.java
+++ b/src/main/java/org/folio/rest/helper/TransactionsHelper.java
@@ -1,11 +1,16 @@
 package org.folio.rest.helper;
 
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ALLOCATION;
+import static org.folio.rest.util.ErrorCodes.ALLOCATION_IDS_MISMATCH;
+import static org.folio.rest.util.ErrorCodes.ALLOCATION_TRANSFER_FAILED;
+import static org.folio.rest.util.ErrorCodes.MISSING_FUND_ID;
 import static org.folio.rest.util.HelperUtils.buildQueryParam;
 import static org.folio.rest.util.ResourcePathResolver.TRANSACTIONS;
 import static org.folio.rest.util.ResourcePathResolver.resourceByIdPath;
 import static org.folio.rest.util.ResourcePathResolver.resourcesPath;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.rest.exception.HttpException;
@@ -27,7 +32,9 @@ public class TransactionsHelper extends AbstractHelper {
   }
 
   public CompletableFuture<Transaction> createTransaction(Transaction transaction) {
-    return handleCreateRequest(resourcesPath(TRANSACTIONS), transaction).thenApply(transaction::withId);
+    return checkRestrictions(transaction)
+      .thenCompose(res -> handleCreateRequest(resourcesPath(TRANSACTIONS), res)
+      .thenApply(res::withId));
   }
 
   public CompletableFuture<TransactionCollection> getTransactions(int limit, int offset, String query) {
@@ -90,4 +97,34 @@ public class TransactionsHelper extends AbstractHelper {
     return updateTransaction(transaction);
   }
 
+  private CompletableFuture<Transaction> checkRestrictions(Transaction transaction) {
+    CompletableFuture<Transaction> future = new VertxCompletableFuture<>(ctx);
+    switch(transaction.getTransactionType()) {
+    case ALLOCATION:
+    case TRANSFER:
+      if (Objects.nonNull(transaction.getFromFundId()) && Objects.nonNull(transaction.getToFundId())) {
+        checkAllocatedIds(transaction)
+          .thenApply(isMatch ->
+            isMatch ? future.complete(transaction) : future.completeExceptionally(new HttpException(422, ALLOCATION_IDS_MISMATCH)))
+          .exceptionally(throwable -> future.completeExceptionally(new HttpException(500, ALLOCATION_TRANSFER_FAILED)));
+      } else if ((Objects.isNull(transaction.getFromFundId()) ^ Objects.isNull(transaction.getToFundId())) &&
+        transaction.getTransactionType().equals(ALLOCATION)) {
+        future.complete(transaction);
+      } else {
+        future.completeExceptionally(new HttpException(422, MISSING_FUND_ID));
+      }
+      break;
+    default:
+      future.complete(transaction);
+    }
+    return future;
+  }
+
+  private CompletableFuture<Boolean> checkAllocatedIds(Transaction transaction) {
+    FundsHelper fundsHelper = new FundsHelper(okapiHeaders, ctx, lang);
+    return fundsHelper.getFund(transaction.getFromFundId())
+      .thenCombine(fundsHelper.getFund(transaction.getToFundId()), (from, to) ->
+        (from.getFund().getAllocatedToIds().isEmpty() || from.getFund().getAllocatedToIds().contains(transaction.getToFundId())) &&
+          (to.getFund().getAllocatedFromIds().isEmpty() || to.getFund().getAllocatedFromIds().contains(transaction.getFromFundId())));
+  }
 }

--- a/src/main/java/org/folio/rest/helper/TransactionsHelper.java
+++ b/src/main/java/org/folio/rest/helper/TransactionsHelper.java
@@ -101,15 +101,15 @@ public class TransactionsHelper extends AbstractHelper {
     CompletableFuture<Transaction> future = new VertxCompletableFuture<>(ctx);
     switch(transaction.getTransactionType()) {
     case ALLOCATION:
+      if (Objects.isNull(transaction.getFromFundId()) ^ Objects.isNull(transaction.getToFundId())) {
+        future.complete(transaction);
+      }
     case TRANSFER:
       if (Objects.nonNull(transaction.getFromFundId()) && Objects.nonNull(transaction.getToFundId())) {
         checkAllocatedIds(transaction)
           .thenApply(isMatch ->
             isMatch ? future.complete(transaction) : future.completeExceptionally(new HttpException(422, ALLOCATION_IDS_MISMATCH)))
           .exceptionally(throwable -> future.completeExceptionally(new HttpException(500, ALLOCATION_TRANSFER_FAILED)));
-      } else if ((Objects.isNull(transaction.getFromFundId()) ^ Objects.isNull(transaction.getToFundId())) &&
-        transaction.getTransactionType().equals(ALLOCATION)) {
-        future.complete(transaction);
       } else {
         future.completeExceptionally(new HttpException(422, MISSING_FUND_ID));
       }

--- a/src/main/java/org/folio/rest/helper/TransactionsHelper.java
+++ b/src/main/java/org/folio/rest/helper/TransactionsHelper.java
@@ -1,6 +1,5 @@
 package org.folio.rest.helper;
 
-import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ALLOCATION;
 import static org.folio.rest.util.ErrorCodes.ALLOCATION_IDS_MISMATCH;
 import static org.folio.rest.util.ErrorCodes.ALLOCATION_TRANSFER_FAILED;
 import static org.folio.rest.util.ErrorCodes.MISSING_FUND_ID;

--- a/src/main/java/org/folio/rest/impl/FundsApi.java
+++ b/src/main/java/org/folio/rest/impl/FundsApi.java
@@ -75,7 +75,7 @@ public class FundsApi implements FinanceFunds, FinanceFundTypes {
 
     FundsHelper helper = new FundsHelper(headers, ctx, lang);
 
-    helper.getFund(id)
+    helper.getCompositeFund(id)
       .thenAccept(fund -> handler.handle(succeededFuture(helper.buildOkResponse(fund))))
       .exceptionally(fail -> handleErrorResponse(handler, helper, fail));
   }

--- a/src/main/java/org/folio/rest/util/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/util/ErrorCodes.java
@@ -18,7 +18,9 @@ public enum ErrorCodes {
   ALLOWABLE_ENCUMBRANCE_LIMIT_EXCEEDED("allowableEncumbranceLimitExceeded", "Allowable encumbrance limit exceeded"),
   ALLOWABLE_EXPENDITURE_LIMIT_EXCEEDED("allowableExpenditureLimitExceeded", "Allowable expenditures limit exceeded"),
   TRANSACTION_IS_PRESENT_BUDGET_DELETE_ERROR("transactionIsPresentBudgetDeleteError",
-    "Budget related transactions found. Deletion of the budget is forbidden.");
+    "Budget related transactions found. Deletion of the budget is forbidden."),
+  MISSING_FUND_ID("missingFundId", "Missing to/from fund id"),
+  ALLOCATION_IDS_MISMATCH("allowableAllocationIdsMismatch", "Allowable allocation ids mismatch");
 
   private final String code;
   private final String description;

--- a/src/test/java/org/folio/rest/impl/ApiTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/ApiTestSuite.java
@@ -100,4 +100,8 @@ public class ApiTestSuite {
   @Nested
   class ExchangeRateTestNested extends ExchangeRateTest {
   }
+
+  @Nested
+  class TransactionTestNested extends TransactionTest {
+  }
 }

--- a/src/test/java/org/folio/rest/impl/TransactionTest.java
+++ b/src/test/java/org/folio/rest/impl/TransactionTest.java
@@ -1,0 +1,158 @@
+package org.folio.rest.impl;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.ALLOCATION;
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.TRANSFER;
+import static org.folio.rest.util.MockServer.addMockEntry;
+import static org.folio.rest.util.TestEntities.FUND;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.util.TestEntities;
+import org.junit.jupiter.api.Test;
+
+public class TransactionTest extends ApiTestBase {
+  private static final Logger logger = LoggerFactory.getLogger(TransactionTest.class);
+
+  private final String dollars = "USD";
+  private final String FISCAL_YEAR_ID = "684b5dc5-92f6-4db7-b996-b549d88f5e4e";
+  private final String HIST_ID = "fb7b70f1-b898-4924-a991-0e4b6312bb5f";
+  private final String CANHIST_ID = "68872d8a-bf16-420b-829f-206da38f6c10";
+  private final String LATHIST_ID = "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79";
+  private final String ASIAHIST_ID = "55f48dc6-efa7-4cfe-bc7c-4786efe493e3";
+
+  @Test
+  public void testTransferAndAllocationWithMatchingAllocatedIds() throws Exception {
+    logger.info("=== Test transfer and allocation toFund.allocatedFromIds matches fromFund.allocatedToIds) - Success ===");
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/HIST.json")));
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/CANHIST.json")));
+
+    // transfer
+    Transaction transaction = createTransaction(TRANSFER)
+      .withFromFundId(HIST_ID)
+      .withToFundId(CANHIST_ID);
+    verifyPostResponse(TestEntities.TRANSACTIONS_TRANSFER.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+
+    // allocation
+    transaction.setTransactionType(ALLOCATION);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+  }
+
+  @Test
+  public void testTransferAndAllocationWithEmptyAllocatedIds() throws Exception {
+    logger.info("=== Test transfer and allocation with empty toFund.allocatedFromIds and fromFund.allocatedToIds - Success ===");
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/CANHIST.json")));
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/LATHIST.json")));
+
+    // transfer
+    Transaction transaction = createTransaction(TRANSFER)
+      .withFromFundId(CANHIST_ID)
+      .withToFundId(LATHIST_ID);
+    JsonObject body = JsonObject.mapFrom(transaction);
+    verifyPostResponse(TestEntities.TRANSACTIONS_TRANSFER.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+
+    // allocation
+    transaction.setTransactionType(ALLOCATION);
+    body = JsonObject.mapFrom(transaction);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+  }
+
+  @Test
+  public void testTransferAndAllocationWithEmptyAllocatedFromIds() throws Exception {
+    logger.info("=== Test transfer and allocation with empty toFund.allocatedFromIds) - Success ===");
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/HIST.json")));
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/LATHIST.json")));
+
+    // transfer
+    Transaction transaction = createTransaction(TRANSFER)
+      .withFromFundId(HIST_ID)
+      .withToFundId(LATHIST_ID);
+    JsonObject body = JsonObject.mapFrom(transaction);
+    verifyPostResponse(TestEntities.TRANSACTIONS_TRANSFER.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+
+    // allocation
+    transaction.setTransactionType(ALLOCATION);
+    body = JsonObject.mapFrom(transaction);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+  }
+
+  @Test
+  public void testTransferAndAllocationWithAllocatedIdsMismatch() throws Exception {
+    logger.info("=== Test transfer and allocation with toFund.allocatedFromIds and fromFund.allocatedToIds mismatch - Unprocessable entity ===");
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/CANHIST.json")));
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/ASIAHIST.json")));
+
+    // transfer
+    Transaction transaction = createTransaction(TRANSFER)
+      .withFromFundId(ASIAHIST_ID)
+      .withToFundId(CANHIST_ID);
+    verifyPostResponse(TestEntities.TRANSACTIONS_TRANSFER.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+
+    // allocation
+    transaction.setTransactionType(ALLOCATION);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+  }
+
+  @Test
+  public void testTransferAndAllocationWithEmptyAllocatedFromIdsMismatch() throws Exception {
+    logger.info("=== Test transfer and allocation with empty fromFund.allocatedToIds mismatch - Unprocessable entity ===");
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/CANHIST.json")));
+    addMockEntry(FUND.name(), new JsonObject(getMockData("mockdata/funds/LATHIST.json")));
+
+    // transfer
+    Transaction transaction = createTransaction(TRANSFER)
+      .withFromFundId(LATHIST_ID)
+      .withToFundId(CANHIST_ID);
+    verifyPostResponse(TestEntities.TRANSACTIONS_TRANSFER.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+
+    // allocation
+    transaction.setTransactionType(ALLOCATION);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+  }
+
+  @Test
+  public void testTransferMissingToOrFromFundId() {
+    logger.info("=== Test transfer missing toFundId or fromFundId - Unprocessable entity ===");
+
+    // missing toFundId
+    Transaction transaction = createTransaction(TRANSFER)
+      .withFromFundId(HIST_ID);
+    verifyPostResponse(TestEntities.TRANSACTIONS_TRANSFER.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+
+    // missing fromFundId
+    transaction = createTransaction(TRANSFER)
+      .withToFundId(HIST_ID);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+  }
+
+  @Test
+  public void testExternalAllocation() {
+    logger.info("=== Test external allocation (missing fromFundId or toFundId) - Success ===");
+    // external from allocation
+    Transaction transaction = createTransaction(ALLOCATION)
+      .withFromFundId(HIST_ID);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+
+    // external to allocation
+    transaction.setTransactionType(ALLOCATION);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 201);
+  }
+
+  @Test
+  public void testAllocationMissingBothFundIds() {
+    logger.info("=== Test allocation missing both FROM and TO fund ids - Unprocessable entity ===");
+    Transaction transaction = createTransaction(ALLOCATION);
+    verifyPostResponse(TestEntities.TRANSACTIONS_ALLOCATION.getEndpoint(), JsonObject.mapFrom(transaction), APPLICATION_JSON, 422);
+  }
+
+  private Transaction createTransaction(Transaction.TransactionType type) {
+    return new Transaction()
+      .withAmount(25.0)
+      .withCurrency(dollars)
+      .withFiscalYearId(FISCAL_YEAR_ID)
+      .withSource(Transaction.Source.USER)
+      .withTransactionType(type);
+  }
+}

--- a/src/test/resources/mockdata/funds/ASIAHIST.json
+++ b/src/test/resources/mockdata/funds/ASIAHIST.json
@@ -1,0 +1,16 @@
+{
+  "id": "55f48dc6-efa7-4cfe-bc7c-4786efe493e3",
+  "name": "Asian History",
+  "code": "ASIAHIST",
+  "externalAccountNo": "94508839006119",
+  "fundStatus": "Active",
+  "fundTypeId": "0f5f819e-0690-4c20-ad8d-cc23a6ecc585",
+  "description": "use for East, Central, and South Asia",
+  "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1",
+  "allocatedToIds": [
+    "fb7b70f1-b898-4924-a991-0e4b6312bb5f"
+  ],
+  "allocatedFromIds": [
+    "cf23adf0-61ba-4887-bf82-956c4aae2260"
+  ]
+}

--- a/src/test/resources/mockdata/funds/CANHIST.json
+++ b/src/test/resources/mockdata/funds/CANHIST.json
@@ -1,0 +1,10 @@
+{
+  "id": "68872d8a-bf16-420b-829f-206da38f6c10",
+  "name": "Canadian History",
+  "code": "CANHIST",
+  "externalAccountNo": "114929793941270",
+  "fundStatus": "Active",
+  "description": "WAITING FOR ADMIN APPROVAL; use for Canada once CANLATHIST is inactivated",
+  "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1",
+  "allocatedFromIds": ["fb7b70f1-b898-4924-a991-0e4b6312bb5f"]
+}

--- a/src/test/resources/mockdata/funds/HIST.json
+++ b/src/test/resources/mockdata/funds/HIST.json
@@ -1,0 +1,13 @@
+{
+  "id": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
+  "name": "History",
+  "code": "HIST",
+  "externalAccountNo": "276507594438808",
+  "fundStatus": "Active",
+  "description": "subdivided by geographic regions, to match individual selectors",
+  "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1",
+  "allocatedToIds": [
+    "68872d8a-bf16-420b-829f-206da38f6c10",
+    "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79"
+  ]
+}

--- a/src/test/resources/mockdata/funds/LATHIST.json
+++ b/src/test/resources/mockdata/funds/LATHIST.json
@@ -1,0 +1,9 @@
+{
+  "id": "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79",
+  "name": "Latin America History",
+  "code": "LATHIST",
+  "externalAccountNo": "114929793941270",
+  "fundStatus": "Active",
+  "description": "WAITING FOR ADMIN APPROVAL",
+  "ledgerId": "133a7916-f05e-4df4-8f7f-09eb2a7076d1"
+}

--- a/src/test/resources/mockdata/transactions/allocations.json
+++ b/src/test/resources/mockdata/transactions/allocations.json
@@ -6,7 +6,7 @@
       "currency": "USD",
       "description": "PO_Line: History of Incas",
       "fiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
-      "fromFundId": "67cd0046-e4f1-4e4f-9024-adf0b0039d09",
+      "fromFundId": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
       "paymentEncumbranceId": "80c28fb4-c34e-48d6-b8c2-de6660c3e0aa",
       "source": "Invoice",
       "tags": {
@@ -14,7 +14,7 @@
           "important"
         ]
       },
-      "toFundId": "69640328-788e-43fc-9c3c-af39e243f3b7",
+      "toFundId": "68872d8a-bf16-420b-829f-206da38f6c10",
       "transactionType": "Allocation"
     }
   ],

--- a/src/test/resources/mockdata/transactions/transfers.json
+++ b/src/test/resources/mockdata/transactions/transfers.json
@@ -6,7 +6,7 @@
       "currency": "USD",
       "description": "PO_Line: History of Incas",
       "fiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
-      "fromFundId": "67cd0046-e4f1-4e4f-9024-adf0b0039d09",
+      "fromFundId": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
       "paymentEncumbranceId": "80c28fb4-c34e-48d6-b8c2-de6660c3e0aa",
       "source": "Invoice",
       "sourceFiscalYearId": "684b5dc5-92f6-4db7-b996-b549d88f5e4e",
@@ -16,7 +16,7 @@
           "important"
         ]
       },
-      "toFundId": "69640328-788e-43fc-9c3c-af39e243f3b7",
+      "toFundId": "68872d8a-bf16-420b-829f-206da38f6c10",
       "transactionType": "Transfer"
     }
   ],


### PR DESCRIPTION
[MODFIN-110](https://issues.folio.org/browse/MODFIN-110) - Enforce allocatedFromIds and allocatedToIds

## Purpose
Allocations and transfers to/from budgets from another budget should be restricted by the fund.allocatedToIds and fund.allocatedFromIds fields in the funds associated with the budgets involved.

## Approach
* Transfers/allocations between budgets are restricted according to requirements
* Unit tests are updated

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
