### PR TITLE
MODFIN-147 Budget allocation calculation out of sync with transaction log

### DIFF
--- a/src/test/java/org/folio/services/BudgetServiceTest.java
+++ b/src/test/java/org/folio/services/BudgetServiceTest.java
@@ -131,14 +131,19 @@ public class BudgetServiceTest {
 
   @Test
   void testUpdateBudgetWithExceededAllowableEncumbered() {
-    sharedBudget.withAllocated(25000d)
+    sharedBudget
+      .withAllowableExpenditure(110d)
+      .withAllowableEncumbrance(1d);
+
+    Budget budgetFromStorage = new Budget()
+      .withAllocated(25000d)
       .withAvailable(15313.45)
       .withUnavailable(9686.55)
       .withAwaitingPayment(150.60)
       .withEncumbered(7307.4)
-      .withExpenditures(2228.55)
-      .withAllowableExpenditure(110d)
-      .withAllowableEncumbrance(1d);
+      .withExpenditures(2228.55);
+
+    when(budgetMockRestClient.getById(anyString(), any(), any())).thenReturn(CompletableFuture.completedFuture(budgetFromStorage));
 
     CompletableFuture<Void> resultFuture = budgetService.updateBudget(sharedBudget, requestContextMock);
     ExecutionException exception = assertThrows(ExecutionException.class, resultFuture::get);
@@ -149,6 +154,7 @@ public class BudgetServiceTest {
     assertEquals(422, cause.getCode());
     assertEquals(errors, cause.getErrors());
 
+    verify(budgetMockRestClient).getById(eq(sharedBudget.getId()), eq(requestContextMock), eq(Budget.class));
     verify(budgetMockRestClient, never()).put(anyString(), any(), any());
   }
 
@@ -191,16 +197,21 @@ public class BudgetServiceTest {
     assertEquals(budgetFromStorage.getOverEncumbrance(), sharedBudget.getOverEncumbrance());
   }
 
-  @Test()
+  @Test
   void testUpdateBudgetWithExceededAllowableExpenditure() {
-    sharedBudget.withAllocated(25000d)
+    sharedBudget
+      .withAllowableEncumbrance(110d)
+      .withAllowableExpenditure(1d);
+
+    Budget budgetFromStorage = new Budget()
+      .withAllocated(25000d)
       .withAvailable(15313.45)
       .withUnavailable(9686.55)
       .withAwaitingPayment(150.60)
       .withEncumbered(7307.4)
-      .withExpenditures(2228.55)
-      .withAllowableEncumbrance(110d)
-      .withAllowableExpenditure(1d);
+      .withExpenditures(2228.55);
+
+    when(budgetMockRestClient.getById(anyString(), any(), any())).thenReturn(CompletableFuture.completedFuture(budgetFromStorage));
 
     CompletableFuture<Void> resultFuture = budgetService.updateBudget(sharedBudget, requestContextMock);
     ExecutionException exception = assertThrows(ExecutionException.class, resultFuture::get);
@@ -211,6 +222,7 @@ public class BudgetServiceTest {
     assertEquals(422, cause.getCode());
     assertEquals(errors, cause.getErrors());
 
+    verify(budgetMockRestClient).getById(eq(sharedBudget.getId()), eq(requestContextMock), eq(Budget.class));
     verify(budgetMockRestClient, never()).put(anyString(), any(), any());
   }
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODFIN-147 check remaining encumbrance and expenditure after merging budgets from request and storage


## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
