### PR TITLE
[MODFISTO-303] Added the conflict error code

### DIFF
--- a/src/main/java/org/folio/rest/exception/HttpException.java
+++ b/src/main/java/org/folio/rest/exception/HttpException.java
@@ -7,6 +7,9 @@ import org.folio.rest.util.ErrorCodes;
 
 import java.util.Collections;
 
+import static org.folio.rest.util.ErrorCodes.CONFLICT;
+import static org.folio.rest.util.ErrorCodes.GENERIC_ERROR_CODE;
+
 public class HttpException extends RuntimeException {
   private static final long serialVersionUID = 8109197948434861504L;
 
@@ -14,10 +17,11 @@ public class HttpException extends RuntimeException {
   private final transient Errors errors;
 
   public HttpException(int code, String message) {
-    super(StringUtils.isNotEmpty(message) ? message : ErrorCodes.GENERIC_ERROR_CODE.getDescription());
+    super(StringUtils.isNotEmpty(message) ? message : GENERIC_ERROR_CODE.getDescription());
     this.code = code;
+    ErrorCodes ec = code == 409 ? CONFLICT : GENERIC_ERROR_CODE;
     this.errors = new Errors()
-      .withErrors(Collections.singletonList(new Error().withCode(ErrorCodes.GENERIC_ERROR_CODE.getCode()).withMessage(message)))
+      .withErrors(Collections.singletonList(new Error().withCode(ec.getCode()).withMessage(message)))
       .withTotalRecords(1);
   }
 

--- a/src/main/java/org/folio/rest/util/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/util/ErrorCodes.java
@@ -37,7 +37,8 @@ public enum ErrorCodes {
   DELETE_CONNECTED_TO_INVOICE("deleteConnectedToInvoice", "Cannot delete an encumbrance connected to an invoice"),
   TRANSACTION_NOT_RELEASED("transactionNotReleased", "Encumbrance should be released before deletion"),
   UPDATE_PAYMENT_TO_CANCEL_INVOICE("updatePaymentToCancelInvoice", "A payment can only be updated to cancel an invoice"),
-  UPDATE_CREDIT_TO_CANCEL_INVOICE("updateCreditToCancelInvoice", "A credit can only be updated to cancel an invoice");
+  UPDATE_CREDIT_TO_CANCEL_INVOICE("updateCreditToCancelInvoice", "A credit can only be updated to cancel an invoice"),
+  CONFLICT("conflict", "Conflict when updating a record");
 
   private final String code;
   private final String description;


### PR DESCRIPTION
## Purpose
[MODFISTO-303](https://issues.folio.org/browse/MODFISTO-303) - Enable optimistic locking

## Approach
Return the "conflict" error code when a 409 is returned by storage with no XML errors in the response body.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
