### PR TITLE
[MODFIN-274] Incorrect calculation of allocationTo and allocationFrom in case of more than 5 funds exist in ledger or group

### DIFF
--- a/src/test/java/org/folio/rest/util/MockServer.java
+++ b/src/test/java/org/folio/rest/util/MockServer.java
@@ -105,8 +105,8 @@ public class MockServer {
   private static final String ID_PATH_PARAM = "/:" + ID;
   static final String CONFIG_MOCK_PATH = BASE_MOCK_DATA_PATH + "configurationEntries/%s.json";
   private static final String LEDGER_FYS_MOCK_PATH = BASE_MOCK_DATA_PATH + "ledger-fiscal-year/ledger-fiscal-years.json";
-  public static final String TRANSACTION_ALLOCATION_TO_QUERY = ".+transactionType==Allocation.+toFundId==.+(cql.allRecords=1 NOT fromFundId=\"\").+";
-  public static final String TRANSACTION_ALLOCATION_FROM_QUERY = ".+transactionType==Allocation.+fromFundId==.+cql.allRecords=1 NOT toFundId=\"\".+";
+  public static final String TRANSACTION_ALLOCATION_TO_QUERY = ".+transactionType==Allocation.+toFundId==.+";
+  public static final String TRANSACTION_ALLOCATION_FROM_QUERY = ".+transactionType==Allocation.+fromFundId==.+";
 
   private final int port;
   private final Vertx vertx;


### PR DESCRIPTION
## Purpose
When there are more than five funds in one group and move alocation is between that group, an error may occur because the request to retrieving transactions from mod-finance-storage is sent in chunks.

## Approach

- Moved the logic to identify allocation in one group and ledger from CQL query to code.

## Learning
[MODFIN-274](https://issues.folio.org/browse/MODFIN-274)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
