### PR TITLE
[MODFIN-264] Rollback for budget and fund updates

### DIFF
--- a/src/main/java/org/folio/rest/helper/FundsHelper.java
+++ b/src/main/java/org/folio/rest/helper/FundsHelper.java
@@ -247,8 +247,9 @@ public class FundsHelper extends AbstractHelper {
     if (t1 == null) {
       return CompletableFuture.completedFuture(null);
     }
-    fundFromStorage.setVersion(fundFromStorage.getVersion() + 1);
-    return handleUpdateRequest(resourceByIdPath(FUNDS_STORAGE, fundFromStorage.getId(), lang), fundFromStorage)
+    return getFund(fundFromStorage.getId())
+      .thenAccept(latestFund -> fundFromStorage.setVersion(latestFund.getVersion()))
+      .thenCompose(v -> handleUpdateRequest(resourceByIdPath(FUNDS_STORAGE, fundFromStorage.getId(), lang), fundFromStorage))
       .handle((v2, t2) -> {
         throw new CompletionException((t1.getCause()));
       });

--- a/src/main/java/org/folio/rest/helper/FundsHelper.java
+++ b/src/main/java/org/folio/rest/helper/FundsHelper.java
@@ -21,7 +21,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.rest.core.RestClient;
@@ -209,10 +211,19 @@ public class FundsHelper extends AbstractHelper {
   }
 
   public CompletableFuture<Void> updateFund(CompositeFund compositeFund) {
+    Fund fund = compositeFund.getFund();
+    return getFund(fund.getId())
+      .thenCompose(fundFromStorage -> handleUpdateRequest(resourceByIdPath(FUNDS_STORAGE, fund.getId(), lang), fund)
+        .thenCompose(v1 -> updateFundGroups(compositeFund)
+          .handle((v2, t) -> rollbackFundPutIfNeeded(fundFromStorage, t))
+          .thenCompose(Function.identity())
+        )
+      );
+  }
 
+  private CompletableFuture<Void> updateFundGroups(CompositeFund compositeFund) {
     Fund fund = compositeFund.getFund();
     Set<String> groupIds = new HashSet<>(compositeFund.getGroupIds());
-
     return ledgerDetailsService.getCurrentFiscalYear(fund.getLedgerId(), new RequestContext(ctx, okapiHeaders))
       .thenCompose(currentFiscalYear-> {
         if(Objects.nonNull(currentFiscalYear)) {
@@ -221,14 +232,26 @@ public class FundsHelper extends AbstractHelper {
             .thenCompose(groupFundFiscalYearCollection -> {
               List<String> groupIdsFromStorage = StreamEx.of(groupFundFiscalYearCollection).map(GroupFundFiscalYear::getGroupId).toList();
               return createGroupFundFiscalYears(compositeFund, currentFiscalYearId, getSetDifference(groupIdsFromStorage, groupIds))
-                .thenCompose(vVoid -> deleteGroupFundFiscalYears(groupFundFiscalYearIdsForDeletion(groupFundFiscalYearCollection, getSetDifference(groupIds, groupIdsFromStorage))));
+                .thenCompose(vVoid -> deleteGroupFundFiscalYears(groupFundFiscalYearIdsForDeletion(
+                  groupFundFiscalYearCollection, getSetDifference(groupIds, groupIdsFromStorage))));
             });
         } else if(groupIds.isEmpty()) {
           return CompletableFuture.completedFuture(null);
         } else {
           throw new HttpException(422, FISCAL_YEARS_NOT_FOUND);
         }
-      }).thenCompose(vVoid -> handleUpdateRequest(resourceByIdPath(FUNDS_STORAGE, fund.getId(), lang), fund));
+      });
+  }
+
+  private CompletableFuture<Void> rollbackFundPutIfNeeded(Fund fundFromStorage, Throwable t1) {
+    if (t1 == null) {
+      return CompletableFuture.completedFuture(null);
+    }
+    fundFromStorage.setVersion(fundFromStorage.getVersion() + 1);
+    return handleUpdateRequest(resourceByIdPath(FUNDS_STORAGE, fundFromStorage.getId(), lang), fundFromStorage)
+      .handle((v2, t2) -> {
+        throw new CompletionException((t1.getCause()));
+      });
   }
 
   private String getBudgetsCollectionQuery(String currentFiscalYearId, String fundId) {

--- a/src/main/java/org/folio/services/budget/BudgetExpenseClassService.java
+++ b/src/main/java/org/folio/services/budget/BudgetExpenseClassService.java
@@ -63,9 +63,9 @@ public class BudgetExpenseClassService {
 
     return getBudgetExpenseClasses(sharedBudget.getId(), requestContext)
       .thenApply(budgetExpenseClasses -> mapBudgetExpenseClassesByOperation(budgetExpenseClasses, sharedBudget))
-      .thenCompose(budgetExpenseClassHolder -> deleteBudgetExpenseClasses(budgetExpenseClassHolder.getDeleteList(), sharedBudget, requestContext)
+      .thenCompose(budgetExpenseClassHolder -> createBudgetExpenseClasses(budgetExpenseClassHolder.getCreateList(), requestContext)
         .thenCompose(aVoid -> updateBudgetExpenseClasses(budgetExpenseClassHolder.getUpdateList(), requestContext))
-        .thenCompose(aVoid -> createBudgetExpenseClasses(budgetExpenseClassHolder.getCreateList(), requestContext)));
+        .thenCompose(aVoid -> deleteBudgetExpenseClasses(budgetExpenseClassHolder.getDeleteList(), sharedBudget, requestContext)));
   }
 
   private BudgetExpenseClassHolder mapBudgetExpenseClassesByOperation(List<BudgetExpenseClass> budgetExpenseClasses, SharedBudget sharedBudget) {

--- a/src/main/java/org/folio/services/budget/BudgetService.java
+++ b/src/main/java/org/folio/services/budget/BudgetService.java
@@ -72,8 +72,9 @@ public class BudgetService {
     if (t1 == null) {
       return CompletableFuture.completedFuture(null);
     }
-    budgetFromStorage.setVersion(budgetFromStorage.getVersion() + 1);
-    return budgetRestClient.put(budgetFromStorage.getId(), budgetFromStorage, requestContext)
+    return budgetRestClient.getById(budgetFromStorage.getId(), requestContext, Budget.class)
+      .thenAccept(latestBudget -> budgetFromStorage.setVersion(latestBudget.getVersion()))
+      .thenCompose(v -> budgetRestClient.put(budgetFromStorage.getId(), budgetFromStorage, requestContext))
       .handle((v2, t2) -> {
         throw new CompletionException((t1.getCause()));
       });

--- a/src/main/java/org/folio/services/budget/BudgetService.java
+++ b/src/main/java/org/folio/services/budget/BudgetService.java
@@ -12,6 +12,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 
 import static org.folio.rest.util.ErrorCodes.ALLOWABLE_ENCUMBRANCE_LIMIT_EXCEEDED;
 import static org.folio.rest.util.ErrorCodes.ALLOWABLE_EXPENDITURE_LIMIT_EXCEEDED;
@@ -38,13 +40,15 @@ public class BudgetService {
 
   public CompletableFuture<Void> updateBudget(SharedBudget sharedBudget, RequestContext requestContext) {
     return budgetRestClient.getById(sharedBudget.getId(), requestContext, Budget.class)
-      .thenApply(budgetFromStorage -> {
-        SharedBudget mergedBudget = mergeBudgets(sharedBudget, budgetFromStorage);
-        validateBudget(mergedBudget);
-        return mergedBudget;
-      })
-      .thenCompose(updatedSharedBudget -> budgetExpenseClassService.updateBudgetExpenseClassesLinks(updatedSharedBudget, requestContext)
-        .thenCompose(aVoid -> budgetRestClient.put(updatedSharedBudget.getId(), BudgetUtils.convertToBudget(updatedSharedBudget), requestContext)));
+      .thenCompose(budgetFromStorage -> {
+          SharedBudget updatedSharedBudget = mergeBudgets(sharedBudget, budgetFromStorage);
+          validateBudget(updatedSharedBudget);
+          return budgetRestClient.put(updatedSharedBudget.getId(), BudgetUtils.convertToBudget(updatedSharedBudget), requestContext)
+            .thenCompose(aVoid -> budgetExpenseClassService.updateBudgetExpenseClassesLinks(updatedSharedBudget, requestContext)
+              .handle((v, t) -> rollbackBudgetPutIfNeeded(budgetFromStorage, t, requestContext))
+              .thenCompose(Function.identity())
+            );
+      });
   }
 
   private SharedBudget mergeBudgets(SharedBudget sharedBudget, Budget budgetFromStorage) {
@@ -62,6 +66,17 @@ public class BudgetService {
       .withOverExpended(budgetFromStorage.getOverExpended())
       .withNetTransfers(budgetFromStorage.getNetTransfers())
       .withTotalFunding(budgetFromStorage.getAllocated() + budgetFromStorage.getNetTransfers());
+  }
+
+  private CompletableFuture<Void> rollbackBudgetPutIfNeeded(Budget budgetFromStorage, Throwable t1, RequestContext requestContext) {
+    if (t1 == null) {
+      return CompletableFuture.completedFuture(null);
+    }
+    budgetFromStorage.setVersion(budgetFromStorage.getVersion() + 1);
+    return budgetRestClient.put(budgetFromStorage.getId(), budgetFromStorage, requestContext)
+      .handle((v2, t2) -> {
+        throw new CompletionException((t1.getCause()));
+      });
   }
 
   public CompletableFuture<Void> deleteBudget(String id, RequestContext requestContext) {

--- a/src/test/java/org/folio/rest/impl/FundsApiTest.java
+++ b/src/test/java/org/folio/rest/impl/FundsApiTest.java
@@ -575,7 +575,7 @@ public class FundsApiTest {
 
     verifyCurrentFYQuery(fiscalYearOne);
 
-    verifyRsEntitiesQuantity(HttpMethod.PUT, FUND, 0);
+    verifyRsEntitiesQuantity(HttpMethod.PUT, FUND, 2);
     verifyRsEntitiesQuantity(HttpMethod.GET, LEDGER, 1);
     verifyRsEntitiesQuantity(HttpMethod.GET, FISCAL_YEAR, 2);
     verifyRsEntitiesQuantity(HttpMethod.GET, BUDGET, 0);
@@ -610,7 +610,7 @@ public class FundsApiTest {
     String id = body.getJsonObject(FUND_FIELD_NAME).getString(ID);
     RestTestUtils.verifyPut(FUND.getEndpointWithId(id), body, "", 422);
 
-    verifyRsEntitiesQuantity(HttpMethod.PUT, FUND, 0);
+    verifyRsEntitiesQuantity(HttpMethod.PUT, FUND, 2);
     verifyRsEntitiesQuantity(HttpMethod.GET, LEDGER, 1);
     verifyRsEntitiesQuantity(HttpMethod.GET, FISCAL_YEAR, 1);
     verifyRsEntitiesQuantity(HttpMethod.GET, BUDGET, 0);
@@ -636,7 +636,7 @@ public class FundsApiTest {
     String id = body.getJsonObject(FUND_FIELD_NAME).getString(ID);
     RestTestUtils.verifyPut(FUND.getEndpointWithId(id), body, "", INTERNAL_SERVER_ERROR.getStatusCode());
 
-    verifyRsEntitiesQuantity(HttpMethod.PUT, FUND, 0);
+    verifyRsEntitiesQuantity(HttpMethod.PUT, FUND, 2);
     verifyRsEntitiesQuantity(HttpMethod.GET, LEDGER, 1);
     verifyRsEntitiesQuantity(HttpMethod.GET, FISCAL_YEAR, 0);
     verifyRsEntitiesQuantity(HttpMethod.POST, GROUP_FUND_FISCAL_YEAR, 0);

--- a/src/test/resources/mockdata/funds/funds.json
+++ b/src/test/resources/mockdata/funds/funds.json
@@ -1,6 +1,7 @@
 {
   "funds": [
     {
+      "_version": 1,
       "id": "e9285a1c-1dfc-4380-868c-e74073003f43",
       "name": "European History",
       "code": "EUROHIST",


### PR DESCRIPTION
## Purpose
[MODFIN-264](https://issues.folio.org/browse/MODFIN-264) - Optimistic locking ignored when changing expense class and adding group

## Approach
- Switched order of operations for budget and fund updates
- Implemented a rollback in case expense class or group updates fail
- Creating new expense class first, as it is more likely to fail than update and delete
- Updated unit tests

See [integration test](https://github.com/folio-org/folio-integration-tests/pull/842).

## Learning
It's tricky to implement an async operation within an error handling block. I had to return a future in `handle()` and evaluate it afterwards with `.thenCompose(Function.identity())`.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
