### PR TITLE
[MODFIN-308] Keep available negative in summary

### DIFF
--- a/src/main/java/org/folio/services/group/GroupFiscalYearTotalsService.java
+++ b/src/main/java/org/folio/services/group/GroupFiscalYearTotalsService.java
@@ -81,7 +81,7 @@ public class GroupFiscalYearTotalsService {
 
   //    #allocated = initialAllocation.add(allocationTo).subtract(allocationFrom)
   //    #totalFunding = allocated.add(netTransfers)
-  //    #available = totalFunding.subtract(unavailable).max(BigDecimal.ZERO)
+  //    #available = totalFunding.subtract(unavailable)
   //    #cashBalance = totalFunding.subtract(expended)
   //    #overEncumbered = encumbered.subtract(totalFunding.max(BigDecimal.ZERO)).max(BigDecimal.ZERO)
   //    #overExpended = expended.add(awaitingPayment).subtract(totalFunding.max(BigDecimal.ZERO)).max(BigDecimal.ZERO)
@@ -103,7 +103,7 @@ public class GroupFiscalYearTotalsService {
       summary.withTotalFunding(totalFunding.doubleValue());
 
       BigDecimal unavailable = BigDecimal.valueOf(summary.getUnavailable());
-      BigDecimal available = totalFunding.subtract(unavailable).max(BigDecimal.ZERO);
+      BigDecimal available = totalFunding.subtract(unavailable);
       summary.withAvailable(available.doubleValue());
 
       BigDecimal expended = BigDecimal.valueOf(summary.getExpenditures());

--- a/src/main/java/org/folio/services/ledger/LedgerTotalsService.java
+++ b/src/main/java/org/folio/services/ledger/LedgerTotalsService.java
@@ -134,7 +134,7 @@ public class LedgerTotalsService {
 
   //    #allocated = initialAllocation.add(allocationTo).subtract(allocationFrom)
   //    #totalFunding = allocated.add(netTransfers)
-  //    #available = totalFunding.subtract(unavailable).max(BigDecimal.ZERO)
+  //    #available = totalFunding.subtract(unavailable)
   //    #cashBalance = totalFunding.subtract(expended)
   //    #overEncumbered = encumbered.subtract(totalFunding.max(BigDecimal.ZERO)).max(BigDecimal.ZERO)
   //    #overExpended = expended.add(awaitingPayment).subtract(totalFunding.max(BigDecimal.ZERO)).max(BigDecimal.ZERO)
@@ -155,7 +155,7 @@ public class LedgerTotalsService {
       ledger.withTotalFunding(totalFunding.doubleValue());
 
       BigDecimal unavailable = BigDecimal.valueOf(ledger.getUnavailable());
-      BigDecimal available = totalFunding.subtract(unavailable).max(BigDecimal.ZERO);
+      BigDecimal available = totalFunding.subtract(unavailable);
       ledger.withAvailable(available.doubleValue());
 
       BigDecimal expended = BigDecimal.valueOf(ledger.getExpenditures());

--- a/src/test/java/org/folio/rest/impl/GroupFiscalYearSummariesTest.java
+++ b/src/test/java/org/folio/rest/impl/GroupFiscalYearSummariesTest.java
@@ -163,7 +163,7 @@ public class GroupFiscalYearSummariesTest {
     assertEquals(0d, groupFiscalYearSummary1.getNetTransfers());
     assertEquals(100.01, groupFiscalYearSummary1.getTotalFunding());
     assertEquals(160.01, groupFiscalYearSummary1.getUnavailable());
-    assertEquals(0.0, groupFiscalYearSummary1.getAvailable());
+    assertEquals(-60.0, groupFiscalYearSummary1.getAvailable());
     assertEquals(250.01, groupFiscalYearSummary1.getInitialAllocation());
     assertEquals(0d, groupFiscalYearSummary1.getAllocationTo());
     assertEquals(150d, groupFiscalYearSummary1.getAllocationFrom());
@@ -252,7 +252,7 @@ public class GroupFiscalYearSummariesTest {
     GroupFiscalYearSummary groupFiscalYearSummary = actualSummariesMap.get(firstGroupFundFiscalYear.getGroupId()).get(0);
     assertEquals(200d, groupFiscalYearSummary.getAllocated());
     assertEquals(200d, groupFiscalYearSummary.getTotalFunding());
-    assertEquals(0d, groupFiscalYearSummary.getAvailable());
+    assertEquals(-300d, groupFiscalYearSummary.getAvailable());
     assertEquals(500d, groupFiscalYearSummary.getUnavailable());
     assertEquals(0d, groupFiscalYearSummary.getNetTransfers());
     assertEquals(200d, groupFiscalYearSummary.getInitialAllocation());


### PR DESCRIPTION
## Purpose
[MODFIN-308](https://issues.folio.org/browse/MODFIN-308) - Maintain displaying "Available" as a negative number for group and ledger

## Approach
- Made changes suggested in the JIRA (removing `.max(BigDecimal.ZERO)` when calculating available for the summary)
- Updated unit tests

See related [integration test PR](https://github.com/folio-org/folio-integration-tests/pull/885).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
