### PR TITLE
MODFIN-324. Add missing required interface to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -854,6 +854,10 @@
       "version": "3.0"
     },
     {
+      "id": "finance-storage.budget-expense-classes",
+      "version": "2.0"
+    },
+    {
       "id": "finance-storage.fund-types",
       "version": "2.0"
     },


### PR DESCRIPTION
The following interface is missing in "requires" section of module descriptor

{
  "id": "finance-storage.budget-expense-classes",
  "version": "2.0"
} 

https://issues.folio.org/browse/MODFIN-324