### PR TITLE
MODFIN-344. Update module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -96,7 +96,7 @@
             "finance-storage.budgets.item.get",
             "finance-storage.budgets.item.put",
             "finance-storage.transactions.collection.get",
-            "finance-storage.expense-classes.collection.get"
+            "finance-storage.budget-expense-classes.collection.get"
           ]
         }
       ]


### PR DESCRIPTION
## Purpose
Recalculate Budget endpoint uses Get Budget expense classes permission instead of Get expense classes
![image](https://github.com/folio-org/mod-finance/assets/25097693/9e48288c-fa45-4e09-84aa-c6a38861e8df)
