### PR TITLE
[MODFISTO-432] Add a check before deleting encumbrances

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -736,7 +736,8 @@
           "pathPattern": "/finance/transactions/batch-all-or-nothing",
           "permissionsRequired": ["finance.transactions.batch"],
           "modulePermissions": [
-            "finance-storage.transactions.batch"
+            "finance-storage.transactions.batch",
+            "finance-storage.transactions.collection.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/services/transactions/BatchTransactionService.java
+++ b/src/main/java/org/folio/services/transactions/BatchTransactionService.java
@@ -6,13 +6,21 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.core.models.RequestEntry;
+import org.folio.rest.exception.HttpException;
 import org.folio.rest.jaxrs.model.Batch;
 import org.folio.rest.jaxrs.model.Encumbrance;
 import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.jaxrs.model.TransactionCollection;
+
+import java.util.List;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.Collections.singletonList;
+import static org.folio.rest.util.ErrorCodes.DELETE_CONNECTED_TO_INVOICE;
+import static org.folio.rest.util.HelperUtils.convertIdsToCqlQuery;
 import static org.folio.rest.util.ResourcePathResolver.BATCH_TRANSACTIONS_STORAGE;
+import static org.folio.rest.util.ResourcePathResolver.TRANSACTIONS;
 import static org.folio.rest.util.ResourcePathResolver.resourcesPath;
 
 public class BatchTransactionService {
@@ -27,7 +35,8 @@ public class BatchTransactionService {
   }
 
   public Future<Void> processBatch(Batch batch, RequestContext requestContext) {
-    return restClient.postEmptyResponse(resourcesPath(BATCH_TRANSACTIONS_STORAGE), batch, requestContext)
+    return checkDeletions(batch, requestContext)
+      .compose(v -> restClient.postEmptyResponse(resourcesPath(BATCH_TRANSACTIONS_STORAGE), batch, requestContext))
       .onSuccess(v -> logger.info("Batch transaction successful"))
       .onFailure(t -> logger.error("Batch transaction failed, batch={}", JsonObject.mapFrom(batch).encodePrettily(), t));
   }
@@ -69,5 +78,36 @@ public class BatchTransactionService {
     Batch batch = new Batch()
       .withTransactionsToUpdate(singletonList(transaction));
     return processBatch(batch, requestContext);
+  }
+
+  private Future<Void> checkDeletions(Batch batch, RequestContext requestContext) {
+    if (batch.getIdsOfTransactionsToDelete().isEmpty()) {
+      return succeededFuture();
+    }
+    return anyConnectedToInvoice(batch.getIdsOfTransactionsToDelete(), requestContext)
+      .map(connected -> {
+        if (!connected) {
+          return null;
+        }
+        logger.warn("validateDeletion:: Tried to delete transactions but one is connected to an invoice, ids={}",
+          batch.getIdsOfTransactionsToDelete());
+        throw new HttpException(422, DELETE_CONNECTED_TO_INVOICE.toError());
+      });
+  }
+
+  private Future<Boolean> anyConnectedToInvoice(List<String> ids, RequestContext requestContext) {
+    // We want to know if the order with the given encumbrance is connected to an invoice.
+    // To avoid adding a dependency to mod-invoice, we check if there is a related awaitingPayment transaction
+    String query = convertIdsToCqlQuery(ids, "awaitingPayment.encumbranceId", "==", " OR ");
+    return getTransactions(query, requestContext)
+      .map(collection -> collection.getTotalRecords() > 0);
+  }
+
+  private Future<TransactionCollection> getTransactions(String query, RequestContext requestContext) {
+    var requestEntry = new RequestEntry(resourcesPath(TRANSACTIONS))
+      .withOffset(0)
+      .withLimit(Integer.MAX_VALUE)
+      .withQuery(query);
+    return restClient.get(requestEntry.buildEndpoint(), TransactionCollection.class, requestContext);
   }
 }

--- a/src/main/java/org/folio/services/transactions/BatchTransactionService.java
+++ b/src/main/java/org/folio/services/transactions/BatchTransactionService.java
@@ -16,6 +16,7 @@ import org.folio.rest.jaxrs.model.TransactionCollection;
 import java.util.List;
 
 import static io.vertx.core.Future.succeededFuture;
+import static java.lang.Boolean.FALSE;
 import static java.util.Collections.singletonList;
 import static org.folio.rest.util.ErrorCodes.DELETE_CONNECTED_TO_INVOICE;
 import static org.folio.rest.util.HelperUtils.convertIdsToCqlQuery;
@@ -86,7 +87,7 @@ public class BatchTransactionService {
     }
     return anyConnectedToInvoice(batch.getIdsOfTransactionsToDelete(), requestContext)
       .map(connected -> {
-        if (!connected) {
+        if (FALSE.equals(connected)) {
           return null;
         }
         logger.warn("validateDeletion:: Tried to delete transactions but one is connected to an invoice, ids={}",

--- a/src/test/java/org/folio/rest/impl/TransactionApiTest.java
+++ b/src/test/java/org/folio/rest/impl/TransactionApiTest.java
@@ -53,7 +53,7 @@ public class TransactionApiTest {
   private static final String ASIAHIST_ID = "55f48dc6-efa7-4cfe-bc7c-4786efe493e3";
 
   public static final String DELETE_TRANSACTION_ID = UUID.randomUUID().toString();
-  public static final String DELETE_CONNECTED_TRANSACTION_ID = UUID.randomUUID().toString();
+  public static final String DELETE_CONNECTED_TRANSACTION_ID = "ac857ef5-4e21-4929-8b97-1a4ae06add16";
 
   @BeforeAll
   static void before() throws InterruptedException, ExecutionException, TimeoutException {
@@ -383,6 +383,12 @@ public class TransactionApiTest {
   void testTransactionBatch() throws Exception {
     String batchAsString = getMockData("mockdata/transactions/batch_with_patch.json");
     RestTestUtils.verifyPostResponse(resourcesPath(BATCH_TRANSACTIONS), new JsonObject(batchAsString), "", 204);
+  }
+
+  @Test
+  void testTransactionBatchError() throws Exception {
+    String batchAsString = getMockData("mockdata/transactions/batch_with_delete.json");
+    RestTestUtils.verifyPostResponse(resourcesPath(BATCH_TRANSACTIONS), new JsonObject(batchAsString), "", 422);
   }
 
   private Transaction createTransaction(Transaction.TransactionType type) {

--- a/src/test/resources/mockdata/transactions/batch_with_delete.json
+++ b/src/test/resources/mockdata/transactions/batch_with_delete.json
@@ -1,0 +1,3 @@
+{
+  "idsOfTransactionsToDelete": [ "ac857ef5-4e21-4929-8b97-1a4ae06add16" ]
+}


### PR DESCRIPTION
## Purpose
[MODFISTO-432](https://folio-org.atlassian.net/browse/MODFISTO-432) - Implement logic to replace AllOrNothing to process list of transaction from request payload

## Approach
Added a check to make sure encumbrances to delete are not connected to an invoice. This could not be added to mod-finance-storage because it would break the encumbrance script.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
