### PR TITLE
[MODORDERS-1043] Allow removing encumbrance with pending payment if updated in same batch

### DIFF
--- a/src/main/java/org/folio/services/transactions/BatchTransactionService.java
+++ b/src/main/java/org/folio/services/transactions/BatchTransactionService.java
@@ -104,10 +104,8 @@ public class BatchTransactionService {
           }
           Optional<Transaction> matchingPPInBatch = batch.getTransactionsToUpdate().stream()
             .filter(pp -> existingPP.get().getId().equals(pp.getId())).findFirst();
-          if (matchingPPInBatch.isPresent()) {
-            if (matchingPPInBatch.get().getAwaitingPayment().getEncumbranceId() == null) {
-              return;
-            }
+          if (matchingPPInBatch.isPresent() && matchingPPInBatch.get().getAwaitingPayment().getEncumbranceId() == null) {
+            return;
           }
           logger.warn("validateDeletion:: Tried to delete transactions but one is connected to an invoice, id={}", id);
           throw new HttpException(422, DELETE_CONNECTED_TO_INVOICE.toError());

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -50,6 +50,7 @@ import org.folio.services.ledger.LedgerTotalsServiceTest;
 import org.folio.services.protection.AcqUnitMembershipsServiceTest;
 import org.folio.services.protection.AcqUnitsServiceTest;
 import org.folio.services.protection.ProtectionServiceTest;
+import org.folio.services.transactions.BatchTransactionServiceTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -233,5 +234,8 @@ public class ApiTestSuite {
 
   @Nested
   class RecalculateBudgetServiceTestNested extends RecalculateBudgetServiceTest {}
+
+  @Nested
+  class BatchTransactionServiceTestNested extends BatchTransactionServiceTest {}
 
 }

--- a/src/test/java/org/folio/services/transactions/BatchTransactionServiceTest.java
+++ b/src/test/java/org/folio/services/transactions/BatchTransactionServiceTest.java
@@ -1,0 +1,81 @@
+package org.folio.services.transactions;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.jaxrs.model.AwaitingPayment;
+import org.folio.rest.jaxrs.model.Transaction;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.Batch;
+import org.folio.rest.jaxrs.model.TransactionCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.rest.jaxrs.model.Transaction.TransactionType.PENDING_PAYMENT;
+import static org.folio.rest.util.ResourcePathResolver.BATCH_TRANSACTIONS_STORAGE;
+import static org.folio.rest.util.ResourcePathResolver.resourcesPath;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BatchTransactionServiceTest {
+  @Mock
+  private RestClient restClient;
+  @Mock
+  private RequestContext requestContext;
+  @Mock
+  private BaseTransactionService baseTransactionService;
+
+  private BatchTransactionService batchTransactionService;
+
+  @BeforeEach
+  void init() {
+    batchTransactionService = new BatchTransactionService(restClient, baseTransactionService);
+  }
+
+  @Test
+  void testRemovingEncumbranceWithPendingPaymentUpdate() {
+    String encumbranceId = UUID.randomUUID().toString();
+    String pendingPaymentId = UUID.randomUUID().toString();
+    String invoiceId = UUID.randomUUID().toString();
+    String invoiceLineId = UUID.randomUUID().toString();
+    String fundId = UUID.randomUUID().toString();
+    String fiscalYearId = UUID.randomUUID().toString();
+    Transaction existingPendingPayment = new Transaction()
+      .withId(pendingPaymentId)
+      .withTransactionType(PENDING_PAYMENT)
+      .withSourceInvoiceId(invoiceId)
+      .withSourceInvoiceLineId(invoiceLineId)
+      .withFromFundId(fundId)
+      .withFiscalYearId(fiscalYearId)
+      .withCurrency("USD")
+      .withInvoiceCancelled(true)
+      .withAwaitingPayment(new AwaitingPayment()
+        .withEncumbranceId(encumbranceId));
+    TransactionCollection existingPendingPaymentCollection = new TransactionCollection()
+      .withTransactions(List.of(existingPendingPayment))
+      .withTotalRecords(1);
+    Transaction newPendingPayment = JsonObject.mapFrom(existingPendingPayment).mapTo(Transaction.class);
+    newPendingPayment.getAwaitingPayment().setEncumbranceId(null);
+    Batch batch = new Batch()
+      .withIdsOfTransactionsToDelete(List.of(encumbranceId))
+      .withTransactionsToUpdate(List.of(newPendingPayment));
+
+    when(restClient.get(anyString(), any(), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(existingPendingPaymentCollection));
+    when(restClient.postEmptyResponse(eq(resourcesPath(BATCH_TRANSACTIONS_STORAGE)), any(Batch.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture());
+
+    Future<Void> result = batchTransactionService.processBatch(batch, requestContext);
+    assertTrue(result.succeeded());
+  }
+}

--- a/src/test/java/org/folio/services/transactions/BatchTransactionServiceTest.java
+++ b/src/test/java/org/folio/services/transactions/BatchTransactionServiceTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,7 +24,7 @@ import static org.folio.rest.util.ResourcePathResolver.BATCH_TRANSACTIONS_STORAG
 import static org.folio.rest.util.ResourcePathResolver.resourcesPath;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -32,13 +34,12 @@ public class BatchTransactionServiceTest {
   private RestClient restClient;
   @Mock
   private RequestContext requestContext;
-  @Mock
-  private BaseTransactionService baseTransactionService;
 
   private BatchTransactionService batchTransactionService;
 
   @BeforeEach
   void init() {
+    BaseTransactionService baseTransactionService = new BaseTransactionService(restClient);
     batchTransactionService = new BatchTransactionService(restClient, baseTransactionService);
   }
 
@@ -70,7 +71,8 @@ public class BatchTransactionServiceTest {
       .withIdsOfTransactionsToDelete(List.of(encumbranceId))
       .withTransactionsToUpdate(List.of(newPendingPayment));
 
-    when(restClient.get(anyString(), any(), eq(requestContext)))
+    String expectedQuery = URLEncoder.encode("awaitingPayment.encumbranceId==(" + encumbranceId + ")", StandardCharsets.UTF_8);
+    when(restClient.get(contains(expectedQuery), any(), eq(requestContext)))
       .thenReturn(Future.succeededFuture(existingPendingPaymentCollection));
     when(restClient.postEmptyResponse(eq(resourcesPath(BATCH_TRANSACTIONS_STORAGE)), any(Batch.class), eq(requestContext)))
       .thenReturn(Future.succeededFuture());


### PR DESCRIPTION
## Purpose
[MODORDERS-1043](https://folio-org.atlassian.net/browse/MODORDERS-1043) - Remove pending payment encumbrance links when encumbrances are deleted

## Approach
Allow removing an encumbrance linked to an approved invoice if the pending payment link to the encumbrance is removed in the same batch.

See also: [mod-orders PR](https://github.com/folio-org/mod-orders/pull/853), [integration test PR](https://github.com/folio-org/folio-integration-tests/pull/1278).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
