### PR TITLE
[MODFIN-380] Update libraries of dependant acq modules to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
   <properties>
     <!--Project properties-->
     <java.version>17</java.version>
-    <spring.version>6.1.5</spring.version>
+    <spring.version>6.1.14</spring.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <raml-module-builder.version>35.2.0</raml-module-builder.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
     <sonar.exclusions>**/models/*.java</sonar.exclusions>
     <sonar.test.exclusions>**/*Test.java</sonar.test.exclusions>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -42,29 +42,32 @@
     <jsonschema_paths>acq-models/mod-finance/schemas,raml-util/schemas,acq-models/common/schemas</jsonschema_paths>
 
     <!--Dependency Management Properties-->
-    <vertx.version>4.5.4</vertx.version>
-    <junit.jupiter.version>5.10.0</junit.jupiter.version>
-    <log4j.version>2.23.0</log4j.version>
+    <vertx.version>4.5.10</vertx.version>
+    <junit.jupiter.version>5.11.2</junit.jupiter.version>
+    <log4j.version>2.24.1</log4j.version>
 
     <!--Dependency properties-->
-    <mockito.version>5.1.1</mockito.version>
-    <aspectj.version>1.9.21.1</aspectj.version>
-    <rest-assured.version>5.4.0</rest-assured.version>
+    <mockito.version>5.14.2</mockito.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
+    <rest-assured.version>5.5.0</rest-assured.version>
     <folio-di-support.version>2.1.0</folio-di-support.version>
+
+    <!--Folio dependencies properties-->
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
     <mod-configuration-client.version>5.10.0</mod-configuration-client.version>
 
     <!--Maven plugin properties-->
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>
-    <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-    <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
-    <properties-maven-plugin.version>1.2.0</properties-maven-plugin.version>
-    <jsonschema2pojo-maven-plugin.version>1.0.2</jsonschema2pojo-maven-plugin.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+    <jsonschema2pojo-maven-plugin.version>1.2.2</jsonschema2pojo-maven-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
 
     <argLine />
@@ -148,7 +151,7 @@
     <dependency>
       <groupId>one.util</groupId>
       <artifactId>streamex</artifactId>
-      <version>0.8.1</version>
+      <version>0.8.3</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -185,7 +188,7 @@
     <dependency>
       <groupId>org.javamoney</groupId>
       <artifactId>moneta</artifactId>
-      <version>1.4.2</version>
+      <version>1.4.4</version>
       <exclusions>
         <exclusion>
           <groupId>org.javamoney.moneta</groupId>
@@ -355,6 +358,18 @@
             <id>generate_interfaces</id>
             <goals>
               <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
## Purpose
[[MODFIN-380] Update libraries of dependant acq modules to the latest versions
](https://folio-org.atlassian.net/browse/MODFIN-380)

## Approach
- Update versions
- Add module descriptor validator