### PR TITLE
[MODFIN-382] - Add dry-run mode for bulk FY finance updates

### DIFF
--- a/src/main/java/org/folio/rest/impl/FinanceDataApi.java
+++ b/src/main/java/org/folio/rest/impl/FinanceDataApi.java
@@ -10,7 +10,6 @@ import io.vertx.core.Vertx;
 import java.util.Map;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.FyFinanceDataCollection;
@@ -43,13 +42,7 @@ public class FinanceDataApi extends BaseApi implements FinanceFinanceData {
   @Validate
   public void putFinanceFinanceData(FyFinanceDataCollection entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     financeDataService.putFinanceData(entity, new RequestContext(vertxContext, okapiHeaders))
-      .onSuccess(financeDataCollection -> {
-        if (CollectionUtils.isEmpty(financeDataCollection.getFyFinanceData())) {
-          asyncResultHandler.handle(succeededFuture(buildNoContentResponse()));
-        } else {
-          asyncResultHandler.handle(succeededFuture(buildOkResponse(financeDataCollection)));
-        }
-      })
+      .onSuccess(financeDataCollection -> asyncResultHandler.handle(succeededFuture(buildOkResponse(financeDataCollection))))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
 }

--- a/src/main/java/org/folio/rest/impl/FinanceDataApi.java
+++ b/src/main/java/org/folio/rest/impl/FinanceDataApi.java
@@ -6,8 +6,11 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+
 import java.util.Map;
 import javax.ws.rs.core.Response;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.FyFinanceDataCollection;
@@ -40,7 +43,13 @@ public class FinanceDataApi extends BaseApi implements FinanceFinanceData {
   @Validate
   public void putFinanceFinanceData(FyFinanceDataCollection entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     financeDataService.putFinanceData(entity, new RequestContext(vertxContext, okapiHeaders))
-      .onSuccess(v -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
+      .onSuccess(financeDataCollection -> {
+        if (CollectionUtils.isEmpty(financeDataCollection.getFyFinanceData())) {
+          asyncResultHandler.handle(succeededFuture(buildNoContentResponse()));
+        } else {
+          asyncResultHandler.handle(succeededFuture(buildOkResponse(financeDataCollection)));
+        }
+      })
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
 }

--- a/src/main/java/org/folio/services/financedata/FinanceDataService.java
+++ b/src/main/java/org/folio/services/financedata/FinanceDataService.java
@@ -107,7 +107,7 @@ public class FinanceDataService {
 
     return processAllocationTransaction(financeDataCollection, requestContext)
       .compose(v -> updateFinanceData(financeDataCollection, requestContext))
-      .map(v -> new FyFinanceDataCollection())
+      .map(v -> financeDataCollection)
       .onSuccess(asyncResult -> processLogs(financeDataCollection, requestContext, COMPLETED))
       .onFailure(asyncResult -> processLogs(financeDataCollection, requestContext, ERROR));
   }

--- a/src/test/java/org/folio/rest/impl/FinanceDataApiTest.java
+++ b/src/test/java/org/folio/rest/impl/FinanceDataApiTest.java
@@ -5,7 +5,6 @@ import static io.vertx.core.Future.succeededFuture;
 import static java.util.Collections.emptyList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.folio.rest.util.ErrorCodes.GENERIC_ERROR_CODE;
 import static org.folio.rest.util.RestTestUtils.verifyGet;
@@ -140,10 +139,12 @@ public class FinanceDataApiTest {
   void positive_testPutFinanceFinanceDataSuccess() throws IOException {
     var financeDataCollection = getFinanceDataCollection();
     when(financeDataService.putFinanceData(any(FyFinanceDataCollection.class), any(RequestContext.class)))
-      .thenReturn(succeededFuture(new FyFinanceDataCollection()));
+      .thenReturn(succeededFuture(financeDataCollection));
 
-    verifyPut(FINANCE_DATA_ENDPOINT, financeDataCollection, "", NO_CONTENT.getStatusCode());
+    var response = verifyPut(FINANCE_DATA_ENDPOINT, financeDataCollection, APPLICATION_JSON, OK.getStatusCode())
+      .as(FyFinanceDataCollection.class);
 
+    assertEquals(financeDataCollection, response);
     verify(financeDataService).putFinanceData(eq(financeDataCollection), any(RequestContext.class));
   }
 
@@ -184,10 +185,12 @@ public class FinanceDataApiTest {
       .withTotalRecords(0);
 
     when(financeDataService.putFinanceData(any(FyFinanceDataCollection.class), any(RequestContext.class)))
-      .thenReturn(succeededFuture(new FyFinanceDataCollection()));
+      .thenReturn(succeededFuture(entity));
 
-    verifyPut(FINANCE_DATA_ENDPOINT, entity, "", NO_CONTENT.getStatusCode());
+    var response = verifyPut(FINANCE_DATA_ENDPOINT, entity, APPLICATION_JSON, OK.getStatusCode())
+      .as(FyFinanceDataCollection.class);
 
+    assertEquals(entity, response);
     verify(financeDataService).putFinanceData(eq(entity), any(RequestContext.class));
   }
 
@@ -214,11 +217,13 @@ public class FinanceDataApiTest {
 
   static class ContextConfiguration {
 
-    @Bean public FinanceDataService financeDataService() {
+    @Bean
+    public FinanceDataService financeDataService() {
       return mock(FinanceDataService.class);
     }
 
-    @Bean AcqUnitsService acqUnitsService() {
+    @Bean
+    AcqUnitsService acqUnitsService() {
       return mock(AcqUnitsService.class);
     }
   }

--- a/src/test/resources/mockdata/finance-data/fy_finance_data_collection_put.json
+++ b/src/test/resources/mockdata/finance-data/fy_finance_data_collection_put.json
@@ -28,8 +28,7 @@
       "transactionDescription": "End of year adjustment",
       "transactionTag": {
         "tagList": ["Urgent", "Review"]
-      },
-      "updateType": "Commit"
+      }
     },
     {
       "fiscalYearId": "123e4567-e89b-12d3-a456-426614174005",
@@ -59,9 +58,9 @@
       "transactionDescription": "Mid-year adjustment",
       "transactionTag": {
         "tagList": ["Urgent", "Review"]
-      },
-      "updateType": "Preview"
+      }
     }
   ],
+  "updateType": "Commit",
   "totalRecords": 2
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODFIN-70 - Logging Improvement

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." 
  instead, provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  the project reconstructs the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODFIN-70
 -->
[Add dry-run mode for bulk FY finance updates](https://folio-org.atlassian.net/browse/MODFIN-382)
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did but help other
 developers *work* with your solution in the future.
-->
- added new update type
- added calculation of after allocation
- updated service to skip commit to db section if update type is preview