### PR TITLE
[MODFISTO-517] Moved group-fund-fiscal-year update when creating a budget to mod-finance-storage

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -21,8 +21,6 @@
           "modulePermissions": [
             "finance-storage.budgets.item.post",
             "finance-storage.budgets.collection.get",
-            "finance-storage.group-fund-fiscal-years.collection.get",
-            "finance-storage.group-fund-fiscal-years.item.put",
             "finance-storage.fiscal-years.item.get",
             "finance-storage.fiscal-years.collection.get",
             "finance-storage.budget-expense-classes.collection.get",
@@ -812,7 +810,12 @@
           "pathPattern": "/finance/finance-data",
           "permissionsRequired": ["finance.finance-data.collection.put"],
           "modulePermissions": [
-            "finance-storage.finance-data.collection.put"
+            "finance-storage.budgets.item.get",
+            "finance-storage.finance-data.collection.put",
+            "finance-storage.fund-update-logs.item.get",
+            "finance-storage.fund-update-logs.item.post",
+            "finance-storage.fund-update-logs.item.put",
+            "finance-storage.funds.item.get"
           ]
         }
       ]

--- a/src/main/java/org/folio/config/ServicesConfiguration.java
+++ b/src/main/java/org/folio/config/ServicesConfiguration.java
@@ -170,12 +170,11 @@ public class ServicesConfiguration {
 
   @Bean
   CreateBudgetService createBudgetService(RestClient restClient,
-                                                             GroupFundFiscalYearService groupFundFiscalYearService,
                                                              FundFiscalYearService fundFiscalYearService,
                                                              BudgetExpenseClassService budgetExpenseClassService,
                                                              TransactionService transactionService,
                                                              FundDetailsService fundDetailsService) {
-    return new CreateBudgetService(restClient, groupFundFiscalYearService, fundFiscalYearService,
+    return new CreateBudgetService(restClient, fundFiscalYearService,
       budgetExpenseClassService, transactionService,  fundDetailsService);
   }
 

--- a/src/main/java/org/folio/services/budget/CreateBudgetService.java
+++ b/src/main/java/org/folio/services/budget/CreateBudgetService.java
@@ -24,7 +24,6 @@ import org.folio.rest.util.ErrorCodes;
 import org.folio.rest.util.ExpenseClassConverterUtils;
 import org.folio.services.fund.FundDetailsService;
 import org.folio.services.fund.FundFiscalYearService;
-import org.folio.services.group.GroupFundFiscalYearService;
 
 import io.vertx.core.Future;
 import org.folio.services.transactions.TransactionService;

--- a/src/main/java/org/folio/services/budget/CreateBudgetService.java
+++ b/src/main/java/org/folio/services/budget/CreateBudgetService.java
@@ -34,20 +34,17 @@ public class CreateBudgetService {
   private static final Logger log = LogManager.getLogger();
 
   private final RestClient restClient;
-  private final GroupFundFiscalYearService groupFundFiscalYearService;
   private final FundFiscalYearService fundFiscalYearService;
   private final BudgetExpenseClassService budgetExpenseClassService;
   private final TransactionService transactionService;
   private final FundDetailsService fundDetailsService;
 
   public CreateBudgetService(RestClient restClient,
-                             GroupFundFiscalYearService groupFundFiscalYearService,
                              FundFiscalYearService fundFiscalYearService,
                              BudgetExpenseClassService budgetExpenseClassService,
                              TransactionService transactionService,
                              FundDetailsService fundDetailsService) {
     this.restClient = restClient;
-    this.groupFundFiscalYearService = groupFundFiscalYearService;
     this.fundFiscalYearService = fundFiscalYearService;
     this.budgetExpenseClassService = budgetExpenseClassService;
     this.transactionService = transactionService;
@@ -128,8 +125,7 @@ public class CreateBudgetService {
     double allocatedValue = sharedBudget.getAllocated();
     sharedBudget.setAllocated(0d);
     return restClient.post(resourcesPath(BUDGETS_STORAGE), BudgetUtils.convertToBudget(sharedBudget), Budget.class, requestContext)
-      .compose(createdBudget -> allocateToBudget(createdBudget.withAllocated(allocatedValue), requestContext))
-      .compose(createdBudget -> groupFundFiscalYearService.updateBudgetIdForGroupFundFiscalYears(createdBudget, requestContext)
+      .compose(createdBudget -> allocateToBudget(createdBudget.withAllocated(allocatedValue), requestContext)
         .compose(aVoid -> budgetExpenseClassService.createBudgetExpenseClasses(sharedBudget, requestContext))
         .map(aVoid -> BudgetUtils.convertToSharedBudget(createdBudget)
           .withStatusExpenseClasses(sharedBudget.getStatusExpenseClasses())));

--- a/src/main/java/org/folio/services/financedata/FinanceDataService.java
+++ b/src/main/java/org/folio/services/financedata/FinanceDataService.java
@@ -125,6 +125,10 @@ public class FinanceDataService {
 
   private void calculateAfterAllocation(FyFinanceDataCollection financeDataCollection) {
     financeDataCollection.getFyFinanceData().forEach(financeData -> {
+      if (financeData.getBudgetId() == null && financeData.getBudgetAllocationChange() == null) {
+        financeData.setBudgetAfterAllocation(null);
+        return;
+      }
       var allocationChange = BigDecimal.valueOf(requireNonNullElse(financeData.getBudgetAllocationChange(), 0.0));
       var currentAllocation = BigDecimal.valueOf(requireNonNullElse(financeData.getBudgetCurrentAllocation(), 0.0));
       var afterAllocation = currentAllocation.add(allocationChange);

--- a/src/main/java/org/folio/services/financedata/FinanceDataService.java
+++ b/src/main/java/org/folio/services/financedata/FinanceDataService.java
@@ -1,6 +1,7 @@
 package org.folio.services.financedata;
 
 import static io.vertx.core.Future.succeededFuture;
+import static java.util.Objects.requireNonNullElse;
 import static org.folio.rest.jaxrs.model.FundUpdateLog.Status.COMPLETED;
 import static org.folio.rest.jaxrs.model.FundUpdateLog.Status.ERROR;
 import static org.folio.rest.util.HelperUtils.combineCqlExpressions;
@@ -112,9 +113,8 @@ public class FinanceDataService {
       var financeData = financeDataCollection.getFyFinanceData().get(i);
       validateFinanceDataFields(financeData, i, fiscalYearId);
 
-      var allocationChange = financeData.getBudgetAllocationChange();
-      var currentAllocation = financeData.getBudgetCurrentAllocation();
-
+      double allocationChange = requireNonNullElse(financeData.getBudgetAllocationChange(), 0.0);
+      double currentAllocation = requireNonNullElse(financeData.getBudgetCurrentAllocation(), 0.0);
       if (allocationChange < 0 && Math.abs(allocationChange) > currentAllocation) {
         var error = createError("Allocation change cannot be greater than current allocation",
           String.format("financeData[%s].budgetAllocationChange", i), String.valueOf(financeData.getBudgetAllocationChange()));
@@ -125,8 +125,8 @@ public class FinanceDataService {
 
   private void calculateAfterAllocation(FyFinanceDataCollection financeDataCollection) {
     financeDataCollection.getFyFinanceData().forEach(financeData -> {
-      var allocationChange = BigDecimal.valueOf(financeData.getBudgetAllocationChange());
-      var currentAllocation = BigDecimal.valueOf(financeData.getBudgetCurrentAllocation());
+      var allocationChange = BigDecimal.valueOf(requireNonNullElse(financeData.getBudgetAllocationChange(), 0.0));
+      var currentAllocation = BigDecimal.valueOf(requireNonNullElse(financeData.getBudgetCurrentAllocation(), 0.0));
       var afterAllocation = currentAllocation.add(allocationChange);
       financeData.setBudgetAfterAllocation(afterAllocation.doubleValue());
     });

--- a/src/main/java/org/folio/services/group/GroupFundFiscalYearService.java
+++ b/src/main/java/org/folio/services/group/GroupFundFiscalYearService.java
@@ -5,13 +5,10 @@ import static org.folio.rest.util.ResourcePathResolver.resourceByIdPath;
 import static org.folio.rest.util.ResourcePathResolver.resourcesPath;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
-import org.folio.rest.jaxrs.model.Budget;
 import org.folio.rest.jaxrs.model.GroupFundFiscalYear;
 import org.folio.rest.jaxrs.model.GroupFundFiscalYearCollection;
 
@@ -39,20 +36,6 @@ public class GroupFundFiscalYearService {
 
   public Future<Void> deleteGroupFundFiscalYear(String id, RequestContext requestContext) {
     return restClient.delete(resourceByIdPath(GROUP_FUND_FISCAL_YEARS, id), requestContext);
-  }
-
-  public Future<Void> updateBudgetIdForGroupFundFiscalYears(Budget budget, RequestContext requestContext) {
-    return getGroupFundFiscalYearCollection(budget.getFundId(), budget.getFiscalYearId(), requestContext)
-      .compose(gfFys -> processGroupFundFyUpdate(budget, gfFys, requestContext));
-  }
-
-  private Future<Void> processGroupFundFyUpdate(Budget budget, GroupFundFiscalYearCollection gffyCollection, RequestContext requestContext) {
-    var futures = gffyCollection.getGroupFundFiscalYears().stream()
-      .map(gffy -> restClient.put(resourceByIdPath(GROUP_FUND_FISCAL_YEARS, gffy.getId()), gffy.withBudgetId(budget.getId()), requestContext))
-      .collect(Collectors.toList());
-
-     return GenericCompositeFuture.join(futures)
-       .mapEmpty();
   }
 
   public Future<GroupFundFiscalYearCollection> getGroupFundFiscalYearCollection(String fundId, String currentFYId, RequestContext requestContext) {

--- a/src/test/java/org/folio/services/budget/CreateBudgetServiceTest.java
+++ b/src/test/java/org/folio/services/budget/CreateBudgetServiceTest.java
@@ -104,7 +104,6 @@ public class CreateBudgetServiceTest {
       .withFundId(currSharedBudget.getFundId());
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
     when(restClient.post(anyString(), any(), any(), any())).thenReturn(succeededFuture(budgetFromStorage));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
     when(budgetExpenseClassMockService.createBudgetExpenseClasses(any(), any())).thenReturn(succeededFuture(null));
     when(transactionMockService.createAllocationTransaction(any(Budget.class), any())).thenReturn(succeededFuture(null));
 
@@ -125,7 +124,6 @@ public class CreateBudgetServiceTest {
           verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
           verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
           verify(transactionMockService).createAllocationTransaction(eq(budgetFromStorage), eq(requestContextMock));
-          verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(budgetFromStorage), eq(requestContextMock));
           verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(currSharedBudget), eq(requestContextMock));
           vertxTestContext.completeNow();
         });
@@ -141,7 +139,6 @@ public class CreateBudgetServiceTest {
       .withFiscalYearId(plannedSharedBudget.getFiscalYearId())
       .withFundId(plannedSharedBudget.getFundId());
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
     when(restClient.post(anyString(), any(), any(), any())).thenReturn(succeededFuture(budgetFromStorage));
     when(budgetExpenseClassMockService.createBudgetExpenseClasses(any(), any())).thenReturn(succeededFuture(null));
     when(budgetExpenseClassMockService.getBudgetExpenseClasses(currBudget.getId(), requestContextMock)).thenReturn(succeededFuture(currBudgetExpenseClasses));
@@ -169,7 +166,6 @@ public class CreateBudgetServiceTest {
         verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
         verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
         verify(transactionMockService).createAllocationTransaction(eq(budgetFromStorage), eq(requestContextMock));
-        verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(budgetFromStorage), eq(requestContextMock));
         verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(plannedSharedBudget), eq(requestContextMock));
         vertxTestContext.completeNow();
       });
@@ -184,7 +180,6 @@ public class CreateBudgetServiceTest {
       .withFiscalYearId(plannedSharedBudget.getFiscalYearId())
       .withFundId(plannedSharedBudget.getFundId());
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
     when(restClient.post(anyString(), any(), any(), any())).thenReturn(succeededFuture(budgetFromStorage));
     when(budgetExpenseClassMockService.createBudgetExpenseClasses(any(), any())).thenReturn(succeededFuture(null));
     when(budgetExpenseClassMockService.getBudgetExpenseClasses(currBudget.getId(), requestContextMock)).thenReturn(succeededFuture(Collections.emptyList()));
@@ -212,7 +207,6 @@ public class CreateBudgetServiceTest {
         verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
         verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
         verify(transactionMockService).createAllocationTransaction(eq(budgetFromStorage), eq(requestContextMock));
-        verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(budgetFromStorage), eq(requestContextMock));
         verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(plannedSharedBudget), eq(requestContextMock));
         vertxTestContext.completeNow();
       });
@@ -230,7 +224,6 @@ public class CreateBudgetServiceTest {
       .withFiscalYearId(plannedSharedBudget.getFiscalYearId())
       .withFundId(plannedSharedBudget.getFundId());
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
     when(restClient.post(anyString(), any(), any(), any())).thenReturn(succeededFuture(budgetFromStorage));
     when(budgetExpenseClassMockService.createBudgetExpenseClasses(any(), any())).thenReturn(succeededFuture(null));
     when(budgetExpenseClassMockService.getBudgetExpenseClasses(currBudget.getId(), requestContextMock)).thenReturn(succeededFuture(currBudgetExpenseClasses));
@@ -262,7 +255,6 @@ public class CreateBudgetServiceTest {
         verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
         verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
         verify(transactionMockService).createAllocationTransaction(eq(budgetFromStorage), eq(requestContextMock));
-        verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(budgetFromStorage), eq(requestContextMock));
         verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(plannedSharedBudget), eq(requestContextMock));
         vertxTestContext.completeNow();
       });
@@ -278,7 +270,6 @@ public class CreateBudgetServiceTest {
       .withFiscalYearId(plannedSharedBudget.getFiscalYearId())
       .withFundId(plannedSharedBudget.getFundId());
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
     when(restClient.post(anyString(), any(), any(), any())).thenReturn(succeededFuture(budgetFromStorage));
     when(budgetExpenseClassMockService.createBudgetExpenseClasses(any(), any())).thenReturn(succeededFuture(null));
     when(budgetExpenseClassMockService.getBudgetExpenseClasses(currBudget.getId(), requestContextMock)).thenReturn(succeededFuture(currBudgetExpenseClasses));
@@ -308,7 +299,6 @@ public class CreateBudgetServiceTest {
         verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
         verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
         verify(transactionMockService).createAllocationTransaction(eq(budgetFromStorage), eq(requestContextMock));
-        verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(budgetFromStorage), eq(requestContextMock));
         verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(plannedSharedBudget), eq(requestContextMock));
         vertxTestContext.completeNow();
       });
@@ -323,7 +313,6 @@ public class CreateBudgetServiceTest {
       .withFiscalYearId(plannedSharedBudget.getFiscalYearId())
       .withFundId(plannedSharedBudget.getFundId());
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
     when(restClient.post(anyString(), any(), any(), any())).thenReturn(succeededFuture(budgetFromStorage));
     when(budgetExpenseClassMockService.createBudgetExpenseClasses(any(), any())).thenReturn(succeededFuture(null));
     when(budgetExpenseClassMockService.getBudgetExpenseClasses(currBudget.getId(), requestContextMock)).thenReturn(succeededFuture(currBudgetExpenseClasses));
@@ -349,7 +338,6 @@ public class CreateBudgetServiceTest {
         verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
         verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
         verify(transactionMockService).createAllocationTransaction(eq(budgetFromStorage), eq(requestContextMock));
-        verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(budgetFromStorage), eq(requestContextMock));
         verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(plannedSharedBudget), eq(requestContextMock));
         vertxTestContext.completeNow();
       });
@@ -359,7 +347,6 @@ public class CreateBudgetServiceTest {
   void testCreateBudgetWithZeroAllocated(VertxTestContext vertxTestContext) {
     currSharedBudget.withAllocated(0d);
     when(fundFiscalYearMockService.retrievePlannedFiscalYear(any(), any())).thenReturn(succeededFuture(plannedFiscalYear));
-    when(groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(any(), any())).thenReturn(succeededFuture(null));
 
     JsonObject json = JsonObject.mapFrom(currSharedBudget);
     json.remove("statusExpenseClasses");
@@ -381,7 +368,6 @@ public class CreateBudgetServiceTest {
           verify(fundFiscalYearMockService).retrievePlannedFiscalYear(eq(currSharedBudget.getFundId()), eq(requestContextMock));
           verify(restClient).post(anyString(), eq(expectedBudget), eq(Budget.class), eq(requestContextMock));
           verify(transactionMockService, never()).createAllocationTransaction(eq(expectedBudget), eq(requestContextMock));
-          verify(groupFundFiscalYearMockService).updateBudgetIdForGroupFundFiscalYears(eq(expectedBudget), eq(requestContextMock));
           verify(budgetExpenseClassMockService).createBudgetExpenseClasses(eq(currSharedBudget), eq(requestContextMock));
 
           vertxTestContext.completeNow();

--- a/src/test/java/org/folio/services/group/GroupFundFiscalYearServiceTest.java
+++ b/src/test/java/org/folio/services/group/GroupFundFiscalYearServiceTest.java
@@ -1,40 +1,28 @@
 package org.folio.services.group;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.rest.util.ResourcePathResolver.GROUP_FUND_FISCAL_YEARS;
-import static org.folio.rest.util.ResourcePathResolver.resourceByIdPath;
 import static org.folio.rest.util.TestUtils.assertQueryContains;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
-import org.folio.rest.jaxrs.model.Budget;
 import org.folio.rest.jaxrs.model.GroupFundFiscalYear;
 import org.folio.rest.jaxrs.model.GroupFundFiscalYearCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
@@ -53,58 +41,6 @@ public class GroupFundFiscalYearServiceTest {
   @BeforeEach
   public void initMocks() {
     MockitoAnnotations.openMocks(this);
-  }
-
-  @Test
-  void testUpdateBudgetIdForGroupFundFiscalYears(VertxTestContext vertxTestContext) {
-    Budget budget = new Budget()
-      .withId(UUID.randomUUID().toString())
-      .withFundId(UUID.randomUUID().toString())
-      .withFiscalYearId(UUID.randomUUID().toString());
-    GroupFundFiscalYearCollection groupFundFiscalYearCollection = new GroupFundFiscalYearCollection();
-    GroupFundFiscalYear groupFundFiscalYear1= new GroupFundFiscalYear()
-      .withId(UUID.randomUUID().toString())
-      .withFiscalYearId(budget.getFiscalYearId())
-      .withFundId(budget.getFundId())
-      .withGroupId(UUID.randomUUID().toString());
-    GroupFundFiscalYear groupFundFiscalYear2= new GroupFundFiscalYear()
-      .withId(UUID.randomUUID().toString())
-      .withFiscalYearId(budget.getFiscalYearId())
-      .withFundId(budget.getFundId())
-      .withGroupId(UUID.randomUUID().toString());
-
-    groupFundFiscalYearCollection.withGroupFundFiscalYears(Arrays.asList(groupFundFiscalYear1, groupFundFiscalYear2))
-      .withTotalRecords(2);
-
-    when(restClient.get(anyString(), any(), any()))
-      .thenReturn(succeededFuture(groupFundFiscalYearCollection));
-    when(restClient.put(anyString(), any(), any())).thenReturn(succeededFuture(null));
-    when(requestContext.context()).thenReturn(Vertx.vertx().getOrCreateContext());
-
-    Future<Void> future = groupFundFiscalYearMockService.updateBudgetIdForGroupFundFiscalYears(budget, requestContext);
-    vertxTestContext.assertComplete(future)
-      .onComplete(result -> {
-        String expected = String.format("fundId==%s AND fiscalYearId==%s", budget.getFundId(), budget.getFiscalYearId());
-
-        verify(restClient).get(assertQueryContains(expected), eq(GroupFundFiscalYearCollection.class), eq(requestContext));
-
-        ArgumentCaptor<String> idArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<GroupFundFiscalYear> groupFundFiscalYearArgumentCaptor = ArgumentCaptor.forClass(GroupFundFiscalYear.class);
-        verify(restClient, times(2))
-          .put(idArgumentCaptor.capture(), groupFundFiscalYearArgumentCaptor.capture(), eq(requestContext));
-
-        List<String> ids = idArgumentCaptor.getAllValues();
-
-        assertThat(ids, containsInAnyOrder(
-          resourceByIdPath(GROUP_FUND_FISCAL_YEARS, groupFundFiscalYear1.getId()),
-          resourceByIdPath(GROUP_FUND_FISCAL_YEARS, groupFundFiscalYear2.getId()))
-        );
-
-        List<GroupFundFiscalYear> groupFundFiscalYears = groupFundFiscalYearArgumentCaptor.getAllValues();
-        assertThat(groupFundFiscalYears, everyItem(hasProperty("budgetId", is(budget.getId()))));
-
-        vertxTestContext.completeNow();
-      });
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODFISTO-517](https://folio-org.atlassian.net/browse/MODFISTO-517) - Create budget when adding batch allocation to fund without budget

## Approach
- Prevent NPE when current allocation or change is null.
- When creating a budget, do not update group-fund-fiscal-year anymore, as this is now done in mod-finance-storage
- Updated permissions and tests

[mod-finance-storage PR](https://github.com/folio-org/mod-finance-storage/pull/450), [integration test PR](https://github.com/folio-org/folio-integration-tests/pull/1704)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
