### PR TITLE
[MODFIN-416]. Batch allocation logs - restrict by acq units

### DIFF
--- a/src/main/java/org/folio/config/ServicesConfiguration.java
+++ b/src/main/java/org/folio/config/ServicesConfiguration.java
@@ -218,14 +218,14 @@ public class ServicesConfiguration {
   }
 
   @Bean
-  FundUpdateLogService fundUpdateLogService(RestClient restClient) {
-    return new FundUpdateLogService(restClient);
+  FundUpdateLogService fundUpdateLogService(RestClient restClient, AcqUnitsService acqUnitsService) {
+    return new FundUpdateLogService(restClient, acqUnitsService);
   }
 
   @Bean
-  FinanceDataService financeDataService(RestClient restClient, AcqUnitsService acqUnitsService,
+  FinanceDataService financeDataService(RestClient restClient, LedgerService ledgerService, AcqUnitsService acqUnitsService,
                                         FundUpdateLogService fundUpdateLogService, FinanceDataValidator financeDataValidator) {
-    return new FinanceDataService(restClient, acqUnitsService, fundUpdateLogService, financeDataValidator);
+    return new FinanceDataService(restClient, ledgerService, acqUnitsService, fundUpdateLogService, financeDataValidator);
   }
 
   @Bean

--- a/src/main/java/org/folio/services/financedata/FinanceDataValidator.java
+++ b/src/main/java/org/folio/services/financedata/FinanceDataValidator.java
@@ -82,6 +82,7 @@ public class FinanceDataValidator {
     validateRequiredField(combinedErrors, "fundCode", i, financeData.getFundCode());
     validateRequiredField(combinedErrors, "fundName", i, financeData.getFundName());
     validateRequiredField(combinedErrors, "fundStatus", i, financeData.getFundStatus());
+    validateRequiredField(combinedErrors, "ledgerId", i, financeData.getLedgerId());
 
     if (StringUtils.isNotEmpty(financeData.getBudgetId())) {
       validateUuid(combinedErrors, "budgetId", i, financeData.getBudgetId());

--- a/src/main/java/org/folio/services/fund/FundUpdateLogService.java
+++ b/src/main/java/org/folio/services/fund/FundUpdateLogService.java
@@ -1,31 +1,40 @@
 package org.folio.services.fund;
 
+import static org.folio.rest.util.HelperUtils.combineCqlExpressions;
 import static org.folio.rest.util.ResourcePathResolver.FUND_UPDATE_LOGS;
 import static org.folio.rest.util.ResourcePathResolver.JOB_NUMBER;
 import static org.folio.rest.util.ResourcePathResolver.resourceByIdPath;
 import static org.folio.rest.util.ResourcePathResolver.resourcesPath;
 
 import io.vertx.core.Future;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.jaxrs.model.FundUpdateLog;
 import org.folio.rest.jaxrs.model.FundUpdateLogCollection;
 import org.folio.rest.jaxrs.model.JobNumber;
+import org.folio.services.protection.AcqUnitsService;
 
 public class FundUpdateLogService {
 
   private final RestClient restClient;
+  private final AcqUnitsService acqUnitsService;
 
-  public FundUpdateLogService(RestClient restClient) {
+  public FundUpdateLogService(RestClient restClient, AcqUnitsService acqUnitsService) {
     this.restClient = restClient;
+    this.acqUnitsService = acqUnitsService;
   }
 
   public Future<FundUpdateLogCollection> getFundUpdateLogs(String query, int offset, int limit,
                                                            RequestContext requestContext) {
-    var requestEntry = new RequestEntry(resourcesPath(FUND_UPDATE_LOGS))
-      .withOffset(offset).withLimit(limit).withQuery(query);
-    return restClient.get(requestEntry.buildEndpoint(), FundUpdateLogCollection.class, requestContext);
+    return acqUnitsService.buildAcqUnitsCqlClause(requestContext)
+      .map(clause -> StringUtils.isEmpty(query) ? clause : combineCqlExpressions("and", clause, query))
+      .compose(effectiveQuery -> {
+        var requestEntry = new RequestEntry(resourcesPath(FUND_UPDATE_LOGS))
+          .withOffset(offset).withLimit(limit).withQuery(effectiveQuery);
+        return restClient.get(requestEntry.buildEndpoint(), FundUpdateLogCollection.class, requestContext);
+      });
   }
 
   public Future<FundUpdateLog> getFundUpdateLogById(String jobId, RequestContext requestContext) {

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -15,6 +15,7 @@ import org.folio.rest.impl.ExchangeTest;
 import org.folio.rest.impl.FinanceDataApiTest;
 import org.folio.rest.impl.FiscalYearTest;
 import org.folio.rest.impl.FundCodeExpenseClassesApiTest;
+import org.folio.rest.impl.FundUpdateLogApiTest;
 import org.folio.rest.impl.FundsApiTest;
 import org.folio.rest.impl.GroupFiscalYearSummariesTest;
 import org.folio.rest.impl.GroupsApiTest;
@@ -259,4 +260,7 @@ public class ApiTestSuite {
 
   @Nested
   class TransactionTotalApiServiceTestNested extends TransactionTotalApiServiceTest {}
+
+  @Nested
+  class FundUpdateLogApiTestNested extends FundUpdateLogApiTest {}
 }

--- a/src/test/java/org/folio/ApiTestSuite.java
+++ b/src/test/java/org/folio/ApiTestSuite.java
@@ -41,6 +41,7 @@ import org.folio.services.fiscalyear.FiscalYearServiceTest;
 import org.folio.services.fund.FundCodeExpenseClassesServiceTest;
 import org.folio.services.fund.FundDetailsServiceTest;
 import org.folio.services.fund.FundServiceTest;
+import org.folio.services.fund.FundUpdateLogServiceTest;
 import org.folio.services.group.GroupExpenseClassTotalsServiceTest;
 import org.folio.services.group.GroupFundFiscalYearServiceTest;
 import org.folio.services.group.GroupServiceTest;
@@ -263,4 +264,7 @@ public class ApiTestSuite {
 
   @Nested
   class FundUpdateLogApiTestNested extends FundUpdateLogApiTest {}
+
+  @Nested
+  class FundUpdateLogServiceTestNested extends FundUpdateLogServiceTest {}
 }

--- a/src/test/java/org/folio/rest/impl/FundUpdateLogApiTest.java
+++ b/src/test/java/org/folio/rest/impl/FundUpdateLogApiTest.java
@@ -1,0 +1,95 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.ApiTestSuite;
+import org.folio.HttpStatus;
+import org.folio.rest.jaxrs.model.FundUpdateLog;
+import org.folio.rest.jaxrs.model.FundUpdateLogCollection;
+import org.folio.rest.util.RestTestUtils;
+import org.folio.services.fund.FundUpdateLogService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static io.vertx.core.Future.succeededFuture;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.folio.rest.util.MockServer.addMockEntry;
+import static org.folio.rest.util.TestConfig.autowireDependencies;
+import static org.folio.rest.util.TestConfig.clearVertxContext;
+import static org.folio.rest.util.TestConfig.initSpringContext;
+import static org.folio.rest.util.TestConfig.isVerticleNotDeployed;
+import static org.folio.rest.util.TestEntities.FUND_UPDATE_LOG;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class FundUpdateLogApiTest {
+
+  private static boolean runningOnOwn;
+
+  @Autowired public FundUpdateLogService fundUpdateLogService;
+
+  public static final String GROUP_ENDPOINT = "finance/fund-update-logs";
+
+  @BeforeAll
+  static void init() throws InterruptedException, ExecutionException, TimeoutException {
+    if (isVerticleNotDeployed()) {
+      ApiTestSuite.before();
+      runningOnOwn = true;
+    }
+    initSpringContext(ContextConfiguration.class);
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    autowireDependencies(this);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    if (runningOnOwn) {
+      ApiTestSuite.after();
+    }
+    clearVertxContext();
+  }
+
+  @AfterEach
+  void resetMocks() {
+    reset(fundUpdateLogService);
+  }
+
+  @Test
+  void testGetFundUpdateLog() {
+    var fundUpdateLogCollection = new FundUpdateLogCollection()
+      .withFundUpdateLogs(List.of(FUND_UPDATE_LOG.getMockObject().mapTo(FundUpdateLog.class)))
+      .withTotalRecords(1);
+
+    addMockEntry(FUND_UPDATE_LOG.name(), JsonObject.mapFrom(fundUpdateLogCollection));
+    when(fundUpdateLogService.getFundUpdateLogs(anyString(), anyInt(), anyInt(), any()))
+      .thenReturn(succeededFuture(fundUpdateLogCollection));
+
+    RestTestUtils.verifyGetWithParam(GROUP_ENDPOINT, APPLICATION_JSON, HttpStatus.HTTP_OK.toInt(),
+        Map.ofEntries(Map.entry("query", "recordsCount=IN_PROGRESS"), Map.entry("offset", 0), Map.entry("limit", 10)))
+      .as(FundUpdateLogCollection.class);
+  }
+
+  static class ContextConfiguration {
+
+    @Bean
+    FundUpdateLogService fundUpdateLogService() {
+      return mock(FundUpdateLogService.class);
+    }
+  }
+}

--- a/src/test/java/org/folio/rest/impl/FundUpdateLogApiTest.java
+++ b/src/test/java/org/folio/rest/impl/FundUpdateLogApiTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static io.vertx.core.Future.succeededFuture;
+import static java.util.Map.entry;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.folio.rest.util.MockServer.addMockEntry;
 import static org.folio.rest.util.TestConfig.autowireDependencies;
@@ -41,7 +42,7 @@ public class FundUpdateLogApiTest {
 
   @Autowired public FundUpdateLogService fundUpdateLogService;
 
-  public static final String GROUP_ENDPOINT = "finance/fund-update-logs";
+  private static final String ENDPOINT = "finance/fund-update-logs";
 
   @BeforeAll
   static void init() throws InterruptedException, ExecutionException, TimeoutException {
@@ -80,8 +81,8 @@ public class FundUpdateLogApiTest {
     when(fundUpdateLogService.getFundUpdateLogs(anyString(), anyInt(), anyInt(), any()))
       .thenReturn(succeededFuture(fundUpdateLogCollection));
 
-    RestTestUtils.verifyGetWithParam(GROUP_ENDPOINT, APPLICATION_JSON, HttpStatus.HTTP_OK.toInt(),
-        Map.ofEntries(Map.entry("query", "recordsCount=IN_PROGRESS"), Map.entry("offset", 0), Map.entry("limit", 10)))
+    RestTestUtils.verifyGetWithParam(ENDPOINT, APPLICATION_JSON, HttpStatus.HTTP_OK.toInt(),
+        Map.ofEntries(entry("query", "recordsCount=IN_PROGRESS"), entry("offset", 0), entry("limit", 10)))
       .as(FundUpdateLogCollection.class);
   }
 

--- a/src/test/java/org/folio/services/fund/FundUpdateLogServiceTest.java
+++ b/src/test/java/org/folio/services/fund/FundUpdateLogServiceTest.java
@@ -1,0 +1,152 @@
+package org.folio.services.fund;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import lombok.SneakyThrows;
+import org.folio.rest.core.RestClient;
+import org.folio.rest.core.models.RequestContext;
+import org.folio.rest.jaxrs.model.FundUpdateLog;
+import org.folio.rest.jaxrs.model.FundUpdateLogCollection;
+import org.folio.rest.jaxrs.model.JobNumber;
+import org.folio.services.protection.AcqUnitsService;
+import org.folio.util.CopilotGenerated;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.folio.rest.RestConstants.OKAPI_URL;
+import static org.folio.rest.util.TestConfig.mockPort;
+import static org.folio.rest.util.TestConstants.X_OKAPI_TENANT;
+import static org.folio.rest.util.TestConstants.X_OKAPI_TOKEN;
+import static org.folio.rest.util.TestConstants.X_OKAPI_USER_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(VertxExtension.class)
+@CopilotGenerated(partiallyGenerated = true)
+public class FundUpdateLogServiceTest {
+
+  @Mock private RestClient restClient;
+  @Mock private AcqUnitsService acqUnitsService;
+  @InjectMocks private FundUpdateLogService fundUpdateLogService;
+
+  private AutoCloseable openMocks;
+  private RequestContext requestContext;
+
+  @BeforeEach
+  void setUp() {
+    openMocks = MockitoAnnotations.openMocks(this);
+
+    var okapiHeaders = new HashMap<String, String>();
+    okapiHeaders.put(OKAPI_URL, "http://localhost:" + mockPort);
+    okapiHeaders.put(X_OKAPI_TOKEN.getName(), X_OKAPI_TOKEN.getValue());
+    okapiHeaders.put(X_OKAPI_TENANT.getName(), X_OKAPI_TENANT.getValue());
+    okapiHeaders.put(X_OKAPI_USER_ID.getName(), X_OKAPI_USER_ID.getValue());
+
+    requestContext = new RequestContext(Vertx.vertx().getOrCreateContext(), okapiHeaders);
+  }
+
+  @AfterEach
+  @SneakyThrows
+  void afterEach() {
+    if (Objects.nonNull(openMocks)) {
+      openMocks.close();
+    }
+  }
+
+  private static Stream<Arguments> testGetFundUpdateLogsArgs() {
+    return Stream.of(
+      arguments(null, new FundUpdateLogCollection().withTotalRecords(2)),
+      arguments("", new FundUpdateLogCollection().withTotalRecords(2)),
+      arguments("clause", new FundUpdateLogCollection().withTotalRecords(1))
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("testGetFundUpdateLogsArgs")
+  void testGetFundUpdateLogs(String clause, FundUpdateLogCollection expectedCollection, VertxTestContext testContext) {
+    when(acqUnitsService.buildAcqUnitsCqlClause(any())).thenReturn(Future.succeededFuture(clause));
+    when(restClient.get(anyString(), any(), any())).thenReturn(Future.succeededFuture(expectedCollection));
+
+    fundUpdateLogService.getFundUpdateLogs("query", 0, 10, requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+        assertEquals(expectedCollection.getTotalRecords(), result.getTotalRecords());
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  void testGetFundUpdateLogById(VertxTestContext testContext) {
+    var fundUpdateLog = new FundUpdateLog().withId("1");
+    when(restClient.get(anyString(), any(), any())).thenReturn(Future.succeededFuture(fundUpdateLog));
+
+    fundUpdateLogService.getFundUpdateLogById("1", requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+        assertEquals("1", result.getId());
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  void testCreateFundUpdateLog(VertxTestContext testContext) {
+    var fundUpdateLog = new FundUpdateLog().withId("1");
+    when(restClient.post(anyString(), any(), any(), any())).thenReturn(Future.succeededFuture(fundUpdateLog));
+
+    fundUpdateLogService.createFundUpdateLog(fundUpdateLog, requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+        assertEquals("1", result.getId());
+        testContext.completeNow();
+      })));
+  }
+
+  @Test
+  void testUpdateFundUpdateLog(VertxTestContext testContext) {
+    var fundUpdateLog = new FundUpdateLog().withId("1");
+    when(restClient.put(anyString(), any(), any())).thenReturn(Future.succeededFuture(null));
+
+    fundUpdateLogService.updateFundUpdateLog(fundUpdateLog, requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(testContext::completeNow)));
+  }
+
+  @Test
+  void testDeleteFundUpdateLog(VertxTestContext testContext) {
+    var requestContext = mock(RequestContext.class);
+    when(restClient.delete(anyString(), any())).thenReturn(Future.succeededFuture(null));
+
+    fundUpdateLogService.deleteFundUpdateLog("1", requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(testContext::completeNow)));
+  }
+
+  @Test
+  void testGetJobNumber(VertxTestContext testContext) {
+    var expectedJobNumber = new JobNumber().withType(JobNumber.Type.FUND_UPDATE_LOGS);
+    when(restClient.get(anyString(), eq(JobNumber.class), eq(requestContext)))
+      .thenReturn(Future.succeededFuture(expectedJobNumber));
+
+    fundUpdateLogService.getJobNumber(requestContext)
+      .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+        assertNotNull(result);
+        assertEquals(expectedJobNumber.getType(), result.getType());
+        testContext.completeNow();
+      })));
+  }
+}

--- a/src/test/java/org/folio/services/fund/FundUpdateLogServiceTest.java
+++ b/src/test/java/org/folio/services/fund/FundUpdateLogServiceTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
@@ -129,7 +128,6 @@ public class FundUpdateLogServiceTest {
 
   @Test
   void testDeleteFundUpdateLog(VertxTestContext testContext) {
-    var requestContext = mock(RequestContext.class);
     when(restClient.delete(anyString(), any())).thenReturn(Future.succeededFuture(null));
 
     fundUpdateLogService.deleteFundUpdateLog("1", requestContext)

--- a/src/test/resources/mockdata/fund-update-logs/fund-update-logs.json
+++ b/src/test/resources/mockdata/fund-update-logs/fund-update-logs.json
@@ -8,6 +8,10 @@
       "jobDetails": {
         "description": "Updating fund records for the day"
       },
+      "ledgerId": "52e3a0a1-5c21-4516-a9c9-da95db5ed0af",
+      "acqUnitIds": [
+        "ac2164c7-ba3d-1bc2-912c-e35ceccbfaf2"
+      ],
       "status": "IN_PROGRESS",
       "recordsCount": 100
     }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODFIN-416>

## Approach

- Populate `FundUpdateLog` with `ledgerId` and `acqUnitIds` to restrict log fetching by an ACQ Unit on the Ledger
- Add new unit tests and update existing integration tests