### PR TITLE
[MODFIN-405] Support creating an inactive budget with an allocation

### DIFF
--- a/src/main/java/org/folio/services/budget/CreateBudgetService.java
+++ b/src/main/java/org/folio/services/budget/CreateBudgetService.java
@@ -140,7 +140,7 @@ public class CreateBudgetService {
 
   private Future<Budget> createActiveBudgetWithAllocation(Budget budgetToCreate, double allocatedValue,
       RequestContext requestContext) {
-    if (allocatedValue == 0.) {
+    if (allocatedValue == 0d) {
       return restClient.post(resourcesPath(BUDGETS_STORAGE), budgetToCreate, Budget.class, requestContext);
     }
     return restClient.post(resourcesPath(BUDGETS_STORAGE), budgetToCreate, Budget.class, requestContext)
@@ -154,6 +154,6 @@ public class CreateBudgetService {
       return succeededFuture(budget);
     }
     return restClient.put(resourceByIdPath(BUDGETS_STORAGE, budget.getId()), budget.withBudgetStatus(desiredStatus), requestContext)
-    .compose(v -> restClient.get(resourceByIdPath(BUDGETS_STORAGE, budget.getId()), Budget.class, requestContext));
+      .compose(v -> restClient.get(resourceByIdPath(BUDGETS_STORAGE, budget.getId()), Budget.class, requestContext));
   }
 }


### PR DESCRIPTION
## Purpose
[MODFIN-405](https://folio-org.atlassian.net/browse/MODFIN-405) - Current budget is created with incorrect values ​​despite the received error

## Approach
When creating an inactive budget with an allocation:
- First create an active budget
- Then create the allocation
- Then make the budget inactive

When an inactive budget is created without an allocation, simply create the budget with the right status.

[Integration tests PR](https://github.com/folio-org/folio-integration-tests/pull/1736)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
