### PR TITLE
[MODFIN-405] Handle negative budget allocation

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -19,6 +19,7 @@
           "pathPattern": "/finance/budgets",
           "permissionsRequired": ["finance.budgets.item.post"],
           "modulePermissions": [
+            "finance-storage.budgets.item.get",
             "finance-storage.budgets.item.post",
             "finance-storage.budgets.collection.get",
             "finance-storage.fiscal-years.item.get",

--- a/src/main/java/org/folio/rest/util/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/util/ErrorCodes.java
@@ -40,7 +40,8 @@ public enum ErrorCodes {
   UPDATE_CREDIT_TO_CANCEL_INVOICE("updateCreditToCancelInvoice", "A credit can only be updated to cancel an invoice"),
   CONFLICT("conflict", "Conflict when updating a record"),
   BUDGET_STATUS_INCORRECT("budgetStatusIncorrect", "Budget status is incorrect"),
-  FUND_STATUS_INCORRECT("fundStatusIncorrect", "Fund status is incorrect");
+  FUND_STATUS_INCORRECT("fundStatusIncorrect", "Fund status is incorrect"),
+  NEGATIVE_ALLOCATION("negativeBudgetAllocation", "A negative budget allocation is not allowed");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/services/budget/CreateBudgetService.java
+++ b/src/main/java/org/folio/services/budget/CreateBudgetService.java
@@ -54,6 +54,10 @@ public class CreateBudgetService {
 
   public Future<SharedBudget> createBudget(SharedBudget sharedBudget, RequestContext requestContext) {
     log.debug("createBudget:: Creating budget for shared budget id: {}", sharedBudget.getId());
+    if (sharedBudget.getAllocated() < 0d) {
+      log.error("createBudget:: Negative allocation");
+      return Future.failedFuture(new HttpException(422, ErrorCodes.NEGATIVE_ALLOCATION));
+    }
     return fundFiscalYearService.retrievePlannedFiscalYear(BudgetUtils.convertToBudget(sharedBudget)
         .getFundId(), requestContext)
       .compose(plannedFiscalYear -> {


### PR DESCRIPTION
## Purpose
[MODFIN-405](https://folio-org.atlassian.net/browse/MODFIN-405) - Current budget is created with incorrect values ​​despite the received error

## Approach
- Handle negative budget allocation with a new error code.
- Added missing permission.

[Integration test PR](https://github.com/folio-org/folio-integration-tests/pull/1747)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
- Did you modify code to call some additional endpoints?
  - [ ] If so, do you check that necessary module permission added in ModuleDescriptor-template.yaml file?

Ideally, all the PRs involved in breaking changes would be merged on the same day
to avoid breaking the folio-testing environment.
Communication is paramount if that is to be achieved,
especially as the number of inter-module and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems,
ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
