### PR TITLE
[MODFIN-410-3]. Enhance TreasuryGovCustomJsonHandler exception handling

### DIFF
--- a/src/main/java/org/folio/rest/util/ErrorCodes.java
+++ b/src/main/java/org/folio/rest/util/ErrorCodes.java
@@ -41,7 +41,8 @@ public enum ErrorCodes {
   CONFLICT("conflict", "Conflict when updating a record"),
   BUDGET_STATUS_INCORRECT("budgetStatusIncorrect", "Budget status is incorrect"),
   FUND_STATUS_INCORRECT("fundStatusIncorrect", "Fund status is incorrect"),
-  NEGATIVE_ALLOCATION("negativeBudgetAllocation", "A negative budget allocation is not allowed");
+  NEGATIVE_ALLOCATION("negativeBudgetAllocation", "A negative budget allocation is not allowed"),
+  UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY("unsupportedExchangeRateFromCurrency", "Unsupported exchange rate from currency - Treasury.gov handler does not support using other 'from' currencies apart from USD");
 
   private final String code;
   private final String description;

--- a/src/main/java/org/folio/services/exchange/CustomJsonExchangeRateProvider.java
+++ b/src/main/java/org/folio/services/exchange/CustomJsonExchangeRateProvider.java
@@ -49,7 +49,7 @@ public class CustomJsonExchangeRateProvider extends AbstractRateProvider {
   }
 
   public BigDecimal getExchangeRateFromHandler(String from, String to) {
-    var handler =  switch (rateSource.getProviderType()) {
+    var handler = switch (rateSource.getProviderType()) {
       case CURRENCYAPI_COM -> new CurrencyApiCustomJsonHandler(httpClient, rateSource);
       case TREASURY_GOV -> new TreasuryGovCustomJsonHandler(httpClient, rateSource);
       case CONVERA_COM -> new ConveraCustomJsonHandler(httpClient, rateSource);

--- a/src/main/java/org/folio/services/exchange/handler/TreasuryGovCustomJsonHandler.java
+++ b/src/main/java/org/folio/services/exchange/handler/TreasuryGovCustomJsonHandler.java
@@ -45,7 +45,10 @@ public class TreasuryGovCustomJsonHandler extends AbstractCustomJsonHandler {
       return BigDecimal.ONE;
     }
     if (!StringUtils.equals(from, CountryCurrency.USD.name())) {
-      throwHttpExceptionOnUnsupportedFromCurrency(from, to);
+      var errors = List.of(new Error().withCode(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getCode())
+        .withMessage(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getDescription())
+        .withParameters(List.of(new Parameter().withKey(FROM).withValue(from), new Parameter().withKey(TO).withValue(to))));
+      throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), new Errors().withErrors(errors).withTotalRecords(errors.size()));
     }
 
     var requestDate = ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
@@ -65,13 +68,6 @@ public class TreasuryGovCustomJsonHandler extends AbstractCustomJsonHandler {
       .getString(EXCHANGE_RATE);
 
     return new BigDecimal(exchangeRate);
-  }
-
-  private void throwHttpExceptionOnUnsupportedFromCurrency(String from, String to) {
-    var errors = List.of(new Error().withCode(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getCode())
-      .withMessage(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getDescription())
-      .withParameters(List.of(new Parameter().withKey(FROM).withValue(from), new Parameter().withKey(TO).withValue(to))));
-    throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), new Errors().withErrors(errors).withTotalRecords(errors.size()));
   }
 
   enum CountryCurrency {

--- a/src/main/java/org/folio/services/exchange/handler/TreasuryGovCustomJsonHandler.java
+++ b/src/main/java/org/folio/services/exchange/handler/TreasuryGovCustomJsonHandler.java
@@ -6,7 +6,6 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
 import org.folio.rest.exception.HttpException;
-import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ExchangeRateSource;
 import org.folio.rest.jaxrs.model.Parameter;
@@ -45,8 +44,7 @@ public class TreasuryGovCustomJsonHandler extends AbstractCustomJsonHandler {
       return BigDecimal.ONE;
     }
     if (!StringUtils.equals(from, CountryCurrency.USD.name())) {
-      var errors = List.of(new Error().withCode(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getCode())
-        .withMessage(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getDescription())
+      var errors = List.of(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.toError()
         .withParameters(List.of(new Parameter().withKey(FROM).withValue(from), new Parameter().withKey(TO).withValue(to))));
       throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), new Errors().withErrors(errors).withTotalRecords(errors.size()));
     }

--- a/src/main/java/org/folio/services/exchange/handler/TreasuryGovCustomJsonHandler.java
+++ b/src/main/java/org/folio/services/exchange/handler/TreasuryGovCustomJsonHandler.java
@@ -4,7 +4,13 @@ import io.vertx.core.json.JsonObject;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.HttpStatus;
+import org.folio.rest.exception.HttpException;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ExchangeRateSource;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.util.ErrorCodes;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.math.BigDecimal;
@@ -14,10 +20,13 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Log4j2
 public class TreasuryGovCustomJsonHandler extends AbstractCustomJsonHandler {
 
+  private static final String FROM = "from";
+  private static final String TO = "to";
   private static final String URI_TEMPLATE = "%s?fields=country_currency_desc,exchange_rate,record_date"
     + "&filter=country_currency_desc:in:(%s),record_date:lte:%s"
     + "&sort=-record_date"
@@ -32,8 +41,11 @@ public class TreasuryGovCustomJsonHandler extends AbstractCustomJsonHandler {
   @Override
   @SneakyThrows
   public BigDecimal getExchangeRateFromApi(String from, String to) {
+    if (StringUtils.equals(from, to)) {
+      return BigDecimal.ONE;
+    }
     if (!StringUtils.equals(from, CountryCurrency.USD.name())) {
-      throw new IllegalStateException("Current handler supports only USD as a 'from' currency");
+      throwHttpExceptionOnUnsupportedFromCurrency(from, to);
     }
 
     var requestDate = ZonedDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
@@ -53,6 +65,13 @@ public class TreasuryGovCustomJsonHandler extends AbstractCustomJsonHandler {
       .getString(EXCHANGE_RATE);
 
     return new BigDecimal(exchangeRate);
+  }
+
+  private void throwHttpExceptionOnUnsupportedFromCurrency(String from, String to) {
+    var errors = List.of(new Error().withCode(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getCode())
+      .withMessage(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getDescription())
+      .withParameters(List.of(new Parameter().withKey(FROM).withValue(from), new Parameter().withKey(TO).withValue(to))));
+    throw new HttpException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), new Errors().withErrors(errors).withTotalRecords(errors.size()));
   }
 
   enum CountryCurrency {

--- a/src/test/java/org/folio/services/exchange/ExchangeServiceTest.java
+++ b/src/test/java/org/folio/services/exchange/ExchangeServiceTest.java
@@ -86,8 +86,7 @@ public class ExchangeServiceTest {
 
     exchangeService.getExchangeRate("USD", "USD", requestContext)
       .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
-        assertEquals("USD", result.getFrom());
-        assertEquals("USD", result.getTo());
+        assertEquals(result.getFrom(), result.getTo());
         assertEquals(1, result.getExchangeRate());
         testContext.completeNow();
       })));
@@ -104,12 +103,14 @@ public class ExchangeServiceTest {
     exchangeService.getExchangeRate("EUR", "USD", requestContext)
       .onComplete(testContext.failing(throwable -> testContext.verify(() -> {
         if (throwable instanceof HttpException he) {
-          assertEquals(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), he.getCode());
           var error = he.getErrors().getErrors().getFirst();
+          assertEquals(HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), he.getCode());
           assertEquals(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getCode(), error.getCode());
           assertEquals(ErrorCodes.UNSUPPORTED_EXCHANGE_RATE_FROM_CURRENCY.getDescription(), error.getMessage());
+          testContext.completeNow();
+        } else {
+          testContext.failNow(new IllegalStateException("Invalid assertion"));
         }
-        testContext.completeNow();
       })));
   }
 


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODFIN-410>

## Approach

- Replace IllegalStateException with an enhanced HttpException
- Add return 1 if from and to currencies are the same (mimic Java Money Moneta's IDENTITY provider's response)


> Forward conversion: https://github.com/JavaMoney/jsr354-ri/blob/4cab8838260af222fa2d2b1cd2512bc1ae7ee1a9/moneta-convert/moneta-convert-base/src/main/java/org/javamoney/moneta/convert/internal/IdentityRateProvider.java#L70

> Reverse conversion: https://github.com/JavaMoney/jsr354-ri/blob/4cab8838260af222fa2d2b1cd2512bc1ae7ee1a9/moneta-convert/moneta-convert-base/src/main/java/org/javamoney/moneta/convert/internal/IdentityRateProvider.java#L87