### PR TITLE
[MODFIN-433]. Include totals without expense class for expense-classes-totals

### DIFF
--- a/src/main/java/org/folio/models/ExpenseClassUnassigned.java
+++ b/src/main/java/org/folio/models/ExpenseClassUnassigned.java
@@ -1,0 +1,19 @@
+package org.folio.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.jaxrs.model.ExpenseClass;
+
+@Getter
+@AllArgsConstructor
+public enum ExpenseClassUnassigned {
+  ID("UNASSIGNED"),
+  NAME("Unassigned");
+
+  private final String value;
+
+  public static String getExpenseClassName(ExpenseClass expenseClass) {
+    return StringUtils.equals(expenseClass.getId(), ID.getValue()) ? NAME.getValue() : expenseClass.getName();
+  }
+}

--- a/src/main/java/org/folio/rest/impl/BudgetsApi.java
+++ b/src/main/java/org/folio/rest/impl/BudgetsApi.java
@@ -40,39 +40,36 @@ public class BudgetsApi extends BaseApi implements FinanceBudgets {
   @Autowired
   private RecalculateBudgetService recalculateBudgetService;
 
-
   public BudgetsApi() {
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
   }
 
   @Validate
   @Override
-  public void postFinanceBudgets(SharedBudget budget, Map<String, String> headers, Handler<AsyncResult<Response>> handler,
-                                 Context ctx) {
-
+  public void postFinanceBudgets(SharedBudget budget, Map<String, String> headers,
+                                 Handler<AsyncResult<Response>> handler, Context ctx) {
     RequestContext requestContext = new RequestContext(ctx, headers);
     createBudgetService.createBudget(budget, requestContext)
-      .onSuccess(createdBudget -> handler.handle(succeededFuture(buildResponseWithLocation(headers.get(OKAPI_URL), String.format(BUDGETS_LOCATION_PREFIX, createdBudget.getId()), createdBudget))))
+      .onSuccess(createdBudget -> {
+        String format = String.format(BUDGETS_LOCATION_PREFIX, createdBudget.getId());
+        handler.handle(succeededFuture(buildResponseWithLocation(headers.get(OKAPI_URL), format, createdBudget)));
+      })
       .onFailure(fail -> handleErrorResponse(handler, fail));
   }
 
   @Validate
   @Override
   public void getFinanceBudgets(String totalRecords, int offset, int limit, String query, Map<String, String> headers,
-      Handler<AsyncResult<Response>> handler, Context ctx) {
-
+                                Handler<AsyncResult<Response>> handler, Context ctx) {
     budgetService.getBudgets(query, offset, limit, new RequestContext(ctx, headers))
       .onSuccess(budgets -> handler.handle(succeededFuture(buildOkResponse(budgets))))
       .onFailure(fail -> handleErrorResponse(handler, fail));
-
   }
 
   @Validate
   @Override
   public void putFinanceBudgetsById(String id, SharedBudget budget, Map<String, String> headers,
                                     Handler<AsyncResult<Response>> handler, Context ctx) {
-
-
     // Set id if this is available only in path
     if (StringUtils.isEmpty(budget.getId())) {
       budget.setId(id);
@@ -80,47 +77,42 @@ public class BudgetsApi extends BaseApi implements FinanceBudgets {
       handler.handle(succeededFuture(buildErrorResponse(new HttpException(422, MISMATCH_BETWEEN_ID_IN_PATH_AND_BODY))));
       return;
     }
-
     budgetService.updateBudget(budget, new RequestContext(ctx, headers))
       .onSuccess(v -> handler.handle(succeededFuture(buildNoContentResponse())))
       .onFailure(fail -> handleErrorResponse(handler, fail));
-
   }
 
   @Validate
   @Override
   public void getFinanceBudgetsById(String id, Map<String, String> headers, Handler<AsyncResult<Response>> handler,
       Context ctx) {
-
     budgetService.getBudgetById(id, new RequestContext(ctx, headers))
       .onSuccess(budget -> handler.handle(succeededFuture(buildOkResponse(budget))))
       .onFailure(fail -> handleErrorResponse(handler, fail));
-
   }
 
   @Validate
   @Override
   public void deleteFinanceBudgetsById(String id, Map<String, String> headers, Handler<AsyncResult<Response>> handler,
       Context ctx) {
-
     budgetService.deleteBudget(id, new RequestContext(ctx, headers))
       .onSuccess(v -> handler.handle(succeededFuture(buildNoContentResponse())))
       .onFailure(fail -> handleErrorResponse(handler, fail));
-
   }
 
   @Override
-  public void getFinanceBudgetsExpenseClassesTotalsById(String budgetId, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getFinanceBudgetsExpenseClassesTotalsById(String budgetId, Map<String, String> okapiHeaders,
+                                                        Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     budgetExpenseClassTotalsService.getExpenseClassTotals(budgetId, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(obj -> asyncResultHandler.handle(succeededFuture(buildOkResponse(obj))))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
 
   @Override
-  public void postFinanceBudgetsRecalculateById(String budgetId, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postFinanceBudgetsRecalculateById(String budgetId, Map<String, String> okapiHeaders,
+                                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     recalculateBudgetService.recalculateBudget(budgetId, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(obj -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
-
 }

--- a/src/main/java/org/folio/rest/impl/GroupsApi.java
+++ b/src/main/java/org/folio/rest/impl/GroupsApi.java
@@ -40,8 +40,9 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
 
   @Validate
   @Override
-  public void postFinanceGroups(Group entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
+  public void postFinanceGroups(Group entity, Map<String, String> okapiHeaders,
+                                Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
     helper.createGroup(entity, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(type -> asyncResultHandler
         .handle(succeededFuture(buildResponseWithLocation(okapiHeaders.get(OKAPI_URL), String.format(GROUPS_LOCATION_PREFIX, type.getId()), type))))
@@ -50,9 +51,9 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
 
   @Validate
   @Override
-  public void getFinanceGroups(String totalRecords, int offset, int limit, String query, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getFinanceGroups(String totalRecords, int offset, int limit, String query, Map<String, String> okapiHeaders,
+                               Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
-
     helper.getGroups(query, offset, limit, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(groups -> asyncResultHandler.handle(succeededFuture(helper.buildOkResponse(groups))))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
@@ -60,9 +61,9 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
 
   @Validate
   @Override
-  public void putFinanceGroupsById(String id, Group entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
-
+  public void putFinanceGroupsById(String id, Group entity, Map<String, String> okapiHeaders,
+                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                   GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
     // Set id if this is available only in path
     if (isEmpty(entity.getId())) {
       entity.setId(id);
@@ -71,7 +72,6 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
       asyncResultHandler.handle(succeededFuture(helper.buildErrorResponse(422)));
       return;
     }
-
     helper.updateGroup(entity, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(types -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
@@ -79,7 +79,8 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
 
   @Validate
   @Override
-  public void getFinanceGroupsById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getFinanceGroupsById(String id, Map<String, String> okapiHeaders,
+                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
     helper.getGroup(id, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(type -> asyncResultHandler.handle(succeededFuture(buildOkResponse(type))))
@@ -88,7 +89,8 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
 
   @Validate
   @Override
-  public void deleteFinanceGroupsById(String id, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void deleteFinanceGroupsById(String id, Map<String, String> okapiHeaders,
+                                      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
     helper.deleteGroup(id, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(types -> asyncResultHandler.handle(succeededFuture(buildNoContentResponse())))
@@ -97,8 +99,8 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
 
   @Validate
   @Override
-  public void getFinanceGroupsExpenseClassesTotalsById(String groupId, String fiscalYearId, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-
+  public void getFinanceGroupsExpenseClassesTotalsById(String groupId, String fiscalYearId, Map<String, String> okapiHeaders,
+                                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     if (StringUtils.isEmpty(fiscalYearId)) {
       handleErrorResponse(asyncResultHandler, new HttpException(400, MISSING_FISCAL_YEAR_ID));
       return;
@@ -107,6 +109,4 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
       .onSuccess(obj -> asyncResultHandler.handle(succeededFuture(buildOkResponse(obj))))
       .onFailure(fail -> handleErrorResponse(asyncResultHandler, fail));
   }
-
-
 }

--- a/src/main/java/org/folio/rest/impl/GroupsApi.java
+++ b/src/main/java/org/folio/rest/impl/GroupsApi.java
@@ -42,7 +42,7 @@ public class GroupsApi extends BaseApi implements FinanceGroups {
   @Override
   public void postFinanceGroups(Group entity, Map<String, String> okapiHeaders,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-                                GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
+    GroupsHelper helper = new GroupsHelper(okapiHeaders, vertxContext);
     helper.createGroup(entity, new RequestContext(vertxContext, okapiHeaders))
       .onSuccess(type -> asyncResultHandler
         .handle(succeededFuture(buildResponseWithLocation(okapiHeaders.get(OKAPI_URL), String.format(GROUPS_LOCATION_PREFIX, type.getId()), type))))

--- a/src/test/java/org/folio/services/ExpenseClassServiceTest.java
+++ b/src/test/java/org/folio/services/ExpenseClassServiceTest.java
@@ -22,6 +22,7 @@ import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.ExpenseClass;
 import org.folio.rest.jaxrs.model.ExpenseClassCollection;
 import org.folio.rest.util.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,14 +46,20 @@ public class ExpenseClassServiceTest {
   @Mock
   private RequestContext requestContext;
 
+  private AutoCloseable closeable;
+
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.openMocks(this);
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void closeMocks() throws Exception {
+    closeable.close();
   }
 
   @Test
   void getExpenseClassesByBudgetId(VertxTestContext vertxTestContext) {
-
     String budgetId = UUID.randomUUID().toString();
     List<ExpenseClass> expectedExpenseClasses = Collections.singletonList(new ExpenseClass()
       .withName("Test name")
@@ -68,7 +75,7 @@ public class ExpenseClassServiceTest {
     Future<List<ExpenseClass>> future = expenseClassService.getExpenseClassesByBudgetId(budgetId, requestContext);
     vertxTestContext.assertComplete(future)
       .onComplete(result -> {
-        String expectedQuery =  String.format("budgetExpenseClass.budgetId==%s", budgetId);
+        String expectedQuery = String.format("budgetExpenseClass.budgetId==%s", budgetId);
         verify(restClient).get(TestUtils.assertQueryContains(expectedQuery), eq(ExpenseClassCollection.class), eq(requestContext));
         assertEquals(expectedExpenseClasses, result.result());
 
@@ -78,7 +85,6 @@ public class ExpenseClassServiceTest {
 
   @Test
   void getExpenseClassesByBudgetIdsInChunks(VertxTestContext vertxTestContext) {
-
     List<String> budgetIds = Stream.generate(() -> UUID.randomUUID().toString())
       .limit(40)
       .collect(Collectors.toList());
@@ -104,7 +110,5 @@ public class ExpenseClassServiceTest {
 
         vertxTestContext.completeNow();
       });
-
   }
-
 }


### PR DESCRIPTION
### **Purpose**

- <https://folio-org.atlassian.net/browse/MODFIN-433>

### **Approach**

- Update Budget and Group services with new code that will convert transactions without expense classes into a separate group
- This new group will have an id of UNASSIGNED and name of Unassigned, and it will help display the previously hidden totals
- Clean and refactor API and Service classes
- Update unit tests

### **Sample usage**

> A fund without any expense classes

<img width="2556" height="1382" alt="image" src="https://github.com/user-attachments/assets/35291d45-5c0c-4daf-be69-be98ba321c10" />

> A fund with expense classes

<img width="2557" height="1379" alt="image" src="https://github.com/user-attachments/assets/26efd57e-f152-483d-ad82-aa14a5d5cad5" />

> A group with both of the funds shown above

<img width="2557" height="1381" alt="image" src="https://github.com/user-attachments/assets/14bf753a-3d23-4930-8b2f-120b97d9838b" />
  