### PR TITLE
MODFIN-439. Rounding to too many decimals when rolling over budgets and increasing by percentage

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -457,7 +457,8 @@
           "pathPattern": "/finance/ledger-rollovers-budgets",
           "permissionsRequired": ["finance.ledger-rollovers-budgets.collection.get"],
           "modulePermissions": [
-            "finance-storage.ledger-rollovers-budgets.collection.get"
+            "finance-storage.ledger-rollovers-budgets.collection.get",
+            "mod-settings.global.read.stripes-core.prefs.manage"
           ]
         },
         {
@@ -465,7 +466,8 @@
           "pathPattern": "/finance/ledger-rollovers-budgets/{id}",
           "permissionsRequired": ["finance.ledger-rollovers-budgets.item.get"],
           "modulePermissions": [
-            "finance-storage.ledger-rollovers-budgets.item.get"
+            "finance-storage.ledger-rollovers-budgets.item.get",
+            "mod-settings.global.read.stripes-core.prefs.manage"
           ]
         }
       ]

--- a/src/main/java/org/folio/config/ServicesConfiguration.java
+++ b/src/main/java/org/folio/config/ServicesConfiguration.java
@@ -134,8 +134,8 @@ public class ServicesConfiguration {
   }
 
   @Bean
-  LedgerRolloverBudgetsService ledgerRolloverBudgetsService(RestClient restClient) {
-    return new LedgerRolloverBudgetsService(restClient);
+  LedgerRolloverBudgetsService ledgerRolloverBudgetsService(RestClient restClient, CommonSettingsService commonSettingsService) {
+    return new LedgerRolloverBudgetsService(restClient, commonSettingsService);
   }
 
   @Bean

--- a/src/main/java/org/folio/services/ledger/LedgerRolloverBudgetsService.java
+++ b/src/main/java/org/folio/services/ledger/LedgerRolloverBudgetsService.java
@@ -52,6 +52,7 @@ public class LedgerRolloverBudgetsService {
       .withInitialAllocation(roundAmount(budget.getInitialAllocation(), currency, rounding))
       .withAllocationTo(roundAmount(budget.getAllocationTo(), currency, rounding))
       .withAllocationFrom(roundAmount(budget.getAllocationFrom(), currency, rounding))
+      .withAllocated(roundAmount(budget.getAllocated(), currency, rounding))
       .withNetTransfers(roundAmount(budget.getNetTransfers(), currency, rounding))
       .withEncumbered(roundAmount(budget.getEncumbered(), currency, rounding))
       .withAwaitingPayment(roundAmount(budget.getAwaitingPayment(), currency, rounding))

--- a/src/main/java/org/folio/services/ledger/LedgerRolloverBudgetsService.java
+++ b/src/main/java/org/folio/services/ledger/LedgerRolloverBudgetsService.java
@@ -9,18 +9,28 @@ import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.core.models.RequestEntry;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverBudget;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverBudgetCollection;
+import org.folio.services.configuration.CommonSettingsService;
+import org.javamoney.moneta.Money;
 
 import io.vertx.core.Future;
 
+import javax.money.Monetary;
+import javax.money.MonetaryOperator;
+import java.util.Objects;
+
 public class LedgerRolloverBudgetsService {
   private final RestClient restClient;
+  private final CommonSettingsService commonSettingsService;
 
-  public LedgerRolloverBudgetsService(RestClient restClient) {
+  public LedgerRolloverBudgetsService(RestClient restClient, CommonSettingsService commonSettingsService) {
     this.restClient = restClient;
+    this.commonSettingsService = commonSettingsService;
   }
 
   public Future<LedgerFiscalYearRolloverBudget> retrieveLedgerRolloverBudgetById(String id, RequestContext requestContext) {
-    return restClient.get(resourceByIdPath(LEDGER_ROLLOVERS_BUDGETS_STORAGE, id), LedgerFiscalYearRolloverBudget.class, requestContext);
+    return restClient.get(resourceByIdPath(LEDGER_ROLLOVERS_BUDGETS_STORAGE, id), LedgerFiscalYearRolloverBudget.class, requestContext)
+    .compose(budget -> commonSettingsService.getSystemCurrency(requestContext)
+        .map(currency -> withRoundedAmounts(budget, currency)));
   }
 
   public Future<LedgerFiscalYearRolloverBudgetCollection> retrieveLedgerRolloverBudgets(String query, int offset, int limit, RequestContext requestContext) {
@@ -28,6 +38,37 @@ public class LedgerRolloverBudgetsService {
       .withOffset(offset)
       .withLimit(limit)
       .withQuery(query);
-    return restClient.get(requestEntry.buildEndpoint(), LedgerFiscalYearRolloverBudgetCollection.class, requestContext);
+    return restClient.get(requestEntry.buildEndpoint(), LedgerFiscalYearRolloverBudgetCollection.class, requestContext)
+      .compose(collection -> commonSettingsService.getSystemCurrency(requestContext)
+        .map(currency -> {
+          collection.getLedgerFiscalYearRolloverBudgets().forEach(budget -> withRoundedAmounts(budget, currency));
+          return collection;
+        }));
+  }
+
+  private LedgerFiscalYearRolloverBudget withRoundedAmounts(LedgerFiscalYearRolloverBudget budget, String currency) {
+    MonetaryOperator rounding = Monetary.getDefaultRounding();
+    return budget
+      .withInitialAllocation(roundAmount(budget.getInitialAllocation(), currency, rounding))
+      .withAllocationTo(roundAmount(budget.getAllocationTo(), currency, rounding))
+      .withAllocationFrom(roundAmount(budget.getAllocationFrom(), currency, rounding))
+      .withNetTransfers(roundAmount(budget.getNetTransfers(), currency, rounding))
+      .withEncumbered(roundAmount(budget.getEncumbered(), currency, rounding))
+      .withAwaitingPayment(roundAmount(budget.getAwaitingPayment(), currency, rounding))
+      .withExpenditures(roundAmount(budget.getExpenditures(), currency, rounding))
+      .withCredits(roundAmount(budget.getCredits(), currency, rounding))
+      .withUnavailable(roundAmount(budget.getUnavailable(), currency, rounding))
+      .withAvailable(roundAmount(budget.getAvailable(), currency, rounding))
+      .withCashBalance(roundAmount(budget.getCashBalance(), currency, rounding))
+      .withOverEncumbrance(roundAmount(budget.getOverEncumbrance(), currency, rounding))
+      .withOverExpended(roundAmount(budget.getOverExpended(), currency, rounding))
+      .withTotalFunding(roundAmount(budget.getTotalFunding(), currency, rounding));
+  }
+
+  private Double roundAmount(Double amount, String currency, MonetaryOperator rounding) {
+    if (Objects.isNull(amount)) {
+      return null;
+    }
+    return Money.of(amount, currency).with(rounding).getNumber().doubleValue();
   }
 }

--- a/src/test/java/org/folio/services/ledger/LedgerRolloverBudgetsServiceTest.java
+++ b/src/test/java/org/folio/services/ledger/LedgerRolloverBudgetsServiceTest.java
@@ -2,6 +2,9 @@ package org.folio.services.ledger;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.util.TestUtils.assertQueryContains;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -16,6 +19,8 @@ import org.folio.rest.core.RestClient;
 import org.folio.rest.core.models.RequestContext;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverBudget;
 import org.folio.rest.jaxrs.model.LedgerFiscalYearRolloverBudgetCollection;
+import org.folio.services.configuration.CommonSettingsService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,10 +39,19 @@ public class LedgerRolloverBudgetsServiceTest {
 
   @Mock
   private RestClient restClient;
+  @Mock
+  private CommonSettingsService commonSettingsService;
+
+  private AutoCloseable mockitoMocks;
 
   @BeforeEach
   public void initMocks() {
-    MockitoAnnotations.openMocks(this);
+    mockitoMocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void afterEach() throws Exception {
+    mockitoMocks.close();
   }
 
   @Test
@@ -49,12 +63,15 @@ public class LedgerRolloverBudgetsServiceTest {
 
     when(restClient.get(anyString(), any(), any(RequestContext.class)))
       .thenReturn(succeededFuture(new LedgerFiscalYearRolloverBudgetCollection()));
+    when(commonSettingsService.getSystemCurrency(any(RequestContext.class)))
+      .thenReturn(succeededFuture("USD"));
 
     var future = ledgerRolloverBudgetsService.retrieveLedgerRolloverBudgets(query, offset, limit, mock(RequestContext.class));
       vertxTestContext.assertComplete(future)
         .onComplete(result -> {
           assertTrue(result.succeeded());
           verify(restClient).get(assertQueryContains(query), eq(LedgerFiscalYearRolloverBudgetCollection.class), any(RequestContext.class));
+          verify(commonSettingsService).getSystemCurrency(any(RequestContext.class));
           vertxTestContext.completeNow();
         });
   }
@@ -66,6 +83,8 @@ public class LedgerRolloverBudgetsServiceTest {
 
     when(restClient.get(anyString(), any(), any(RequestContext.class)))
       .thenReturn(succeededFuture(new LedgerFiscalYearRolloverBudget()));
+    when(commonSettingsService.getSystemCurrency(any(RequestContext.class)))
+      .thenReturn(succeededFuture("USD"));
 
     var future = ledgerRolloverBudgetsService.retrieveLedgerRolloverBudgetById(id,  mock(RequestContext.class));
       vertxTestContext.assertComplete(future)
@@ -73,7 +92,118 @@ public class LedgerRolloverBudgetsServiceTest {
           assertTrue(result.succeeded());
 
           verify(restClient).get(assertQueryContains(id), eq(LedgerFiscalYearRolloverBudget.class), any(RequestContext.class));
+          verify(commonSettingsService).getSystemCurrency(any(RequestContext.class));
           vertxTestContext.completeNow();
         });
+  }
+
+  @Test
+  void shouldReturnBudgetWithRoundedAmountsWhenCalledRetrieveLedgerRolloverBudgetById(VertxTestContext vertxTestContext) {
+    // Given
+    String id = UUID.randomUUID().toString();
+    LedgerFiscalYearRolloverBudget budgetWithUnroundedAmounts = new LedgerFiscalYearRolloverBudget()
+      .withId(id)
+      .withInitialAllocation(100.123456)
+      .withAllocationTo(200.987654)
+      .withAllocationFrom(50.555555)
+      .withNetTransfers(25.777777)
+      .withEncumbered(75.333333)
+      .withAwaitingPayment(125.666666)
+      .withExpenditures(175.888888)
+      .withCredits(225.111111)
+      .withUnavailable(275.444444)
+      .withAvailable(325.222222)
+      .withCashBalance(375.999999)
+      .withOverEncumbrance(425.123456)
+      .withOverExpended(475.987654)
+      .withTotalFunding(525.555555);
+
+    when(restClient.get(anyString(), any(), any(RequestContext.class)))
+      .thenReturn(succeededFuture(budgetWithUnroundedAmounts));
+    when(commonSettingsService.getSystemCurrency(any(RequestContext.class)))
+      .thenReturn(succeededFuture("USD"));
+
+    var future = ledgerRolloverBudgetsService.retrieveLedgerRolloverBudgetById(id, mock(RequestContext.class));
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        assertTrue(result.succeeded());
+        LedgerFiscalYearRolloverBudget roundedBudget = result.result();
+
+        // Verify amounts are rounded to 2 decimal places (default for USD)
+        assertThat(roundedBudget.getInitialAllocation(), is(100.12));
+        assertThat(roundedBudget.getAllocationTo(), is(200.99));
+        assertThat(roundedBudget.getAllocationFrom(), is(50.56));
+        assertThat(roundedBudget.getNetTransfers(), is(25.78));
+        assertThat(roundedBudget.getEncumbered(), is(75.33));
+        assertThat(roundedBudget.getAwaitingPayment(), is(125.67));
+        assertThat(roundedBudget.getExpenditures(), is(175.89));
+        assertThat(roundedBudget.getCredits(), is(225.11));
+        assertThat(roundedBudget.getUnavailable(), is(275.44));
+        assertThat(roundedBudget.getAvailable(), is(325.22));
+        assertThat(roundedBudget.getCashBalance(), is(376.00));
+        assertThat(roundedBudget.getOverEncumbrance(), is(425.12));
+        assertThat(roundedBudget.getOverExpended(), is(475.99));
+        assertThat(roundedBudget.getTotalFunding(), is(525.56));
+
+        verify(restClient).get(assertQueryContains(id), eq(LedgerFiscalYearRolloverBudget.class), any(RequestContext.class));
+        verify(commonSettingsService).getSystemCurrency(any(RequestContext.class));
+        vertxTestContext.completeNow();
+      });
+  }
+
+  @Test
+  void shouldHandleNullAmountsWhenCalledRetrieveLedgerRolloverBudgetById(VertxTestContext vertxTestContext) {
+    // Given
+    String id = UUID.randomUUID().toString();
+    LedgerFiscalYearRolloverBudget budgetWithNullAmounts = new LedgerFiscalYearRolloverBudget()
+      .withId(id)
+      .withInitialAllocation(100.123456)
+      .withAllocationTo(null)  // null amount
+      .withAllocationFrom(50.555555)
+      .withNetTransfers(null)  // null amount
+      .withEncumbered(75.333333)
+      .withAwaitingPayment(null)  // null amount
+      .withExpenditures(175.888888)
+      .withCredits(225.111111)
+      .withUnavailable(null)  // null amount - this is the one mentioned in the requirement
+      .withAvailable(325.222222)
+      .withCashBalance(null)  // null amount
+      .withOverEncumbrance(425.123456)
+      .withOverExpended(null)  // null amount
+      .withTotalFunding(525.555555);
+
+    when(restClient.get(anyString(), any(), any(RequestContext.class)))
+      .thenReturn(succeededFuture(budgetWithNullAmounts));
+    when(commonSettingsService.getSystemCurrency(any(RequestContext.class)))
+      .thenReturn(succeededFuture("USD"));
+
+    var future = ledgerRolloverBudgetsService.retrieveLedgerRolloverBudgetById(id, mock(RequestContext.class));
+    vertxTestContext.assertComplete(future)
+      .onComplete(result -> {
+        assertTrue(result.succeeded());
+        LedgerFiscalYearRolloverBudget roundedBudget = result.result();
+
+        // Verify non-null amounts are rounded
+        assertThat(roundedBudget.getInitialAllocation(), is(100.12));
+        assertThat(roundedBudget.getAllocationFrom(), is(50.56));
+        assertThat(roundedBudget.getEncumbered(), is(75.33));
+        assertThat(roundedBudget.getExpenditures(), is(175.89));
+        assertThat(roundedBudget.getCredits(), is(225.11));
+        assertThat(roundedBudget.getAvailable(), is(325.22));
+        assertThat(roundedBudget.getOverEncumbrance(), is(425.12));
+        assertThat(roundedBudget.getTotalFunding(), is(525.56));
+
+        // Verify null amounts remain null
+        assertThat(roundedBudget.getAllocationTo(), is(nullValue()));
+        assertThat(roundedBudget.getNetTransfers(), is(nullValue()));
+        assertThat(roundedBudget.getAwaitingPayment(), is(nullValue()));
+        assertThat(roundedBudget.getUnavailable(), is(nullValue()));
+        assertThat(roundedBudget.getCashBalance(), is(nullValue()));
+        assertThat(roundedBudget.getOverExpended(), is(nullValue()));
+
+        verify(restClient).get(assertQueryContains(id), eq(LedgerFiscalYearRolloverBudget.class), any(RequestContext.class));
+        verify(commonSettingsService).getSystemCurrency(any(RequestContext.class));
+        vertxTestContext.completeNow();
+      });
   }
 }

--- a/src/test/java/org/folio/services/ledger/LedgerRolloverBudgetsServiceTest.java
+++ b/src/test/java/org/folio/services/ledger/LedgerRolloverBudgetsServiceTest.java
@@ -106,6 +106,7 @@ public class LedgerRolloverBudgetsServiceTest {
       .withInitialAllocation(100.123456)
       .withAllocationTo(200.987654)
       .withAllocationFrom(50.555555)
+      .withAllocated(150.777777)
       .withNetTransfers(25.777777)
       .withEncumbered(75.333333)
       .withAwaitingPayment(125.666666)
@@ -133,6 +134,7 @@ public class LedgerRolloverBudgetsServiceTest {
         assertThat(roundedBudget.getInitialAllocation(), is(100.12));
         assertThat(roundedBudget.getAllocationTo(), is(200.99));
         assertThat(roundedBudget.getAllocationFrom(), is(50.56));
+        assertThat(roundedBudget.getAllocated(), is(150.78));
         assertThat(roundedBudget.getNetTransfers(), is(25.78));
         assertThat(roundedBudget.getEncumbered(), is(75.33));
         assertThat(roundedBudget.getAwaitingPayment(), is(125.67));


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODFIN-439

### **Approach**
Apply rounding before returning response

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
