### PR TITLE
[MODFIN-460] Fixed conversion with custom exchange rate, validation

### DIFF
--- a/ramls/exchange.raml
+++ b/ramls/exchange.raml
@@ -26,10 +26,14 @@ types:
     description: Exchange calculation expressed as a total calculation of exchange
     example: 99.95
 
+traits:
+  validate: !include raml-util/traits/validation.raml
+
 /finance/calculate-exchange:
   displayName: Calculate exchange
   description: Calculate exchange API
   get:
+    is: [ validate ]
     description: "Get exchange calculation"
     queryParameters:
       from:
@@ -102,6 +106,7 @@ types:
   displayName: Exchange rate
   description: Exchange rate API
   get:
+    is: [ validate ]
     description: "Get exchange rate"
     queryParameters:
       from:

--- a/src/main/java/org/folio/rest/helper/ExchangeHelper.java
+++ b/src/main/java/org/folio/rest/helper/ExchangeHelper.java
@@ -13,10 +13,14 @@ import org.folio.HttpStatus;
 import org.folio.rest.exception.HttpException;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ExchangeRate;
+import org.folio.rest.jaxrs.model.ExchangeRate.OperationMode;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.util.ErrorCodes;
 import org.javamoney.moneta.Money;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
 import java.util.List;
 
 @Log4j2
@@ -31,15 +35,42 @@ public class ExchangeHelper extends AbstractHelper {
 
   public ExchangeRate getExchangeRate(String from, String to) {
     log.debug("getExchangeRate:: Getting exchange rate from={}, to={}", from, to);
+    validateRequiredParameters(List.of("from", "to"), Arrays.asList(from, to));
+    Number rateAsNumber = getRateFactor(from, to);
+    double rateAsDouble = rateAsNumber.doubleValue();
+    log.debug("getExchangeRate:: Fetched exchange rate={}", rateAsDouble);
+    return new ExchangeRate().withFrom(from)
+      .withTo(to)
+      .withExchangeRate(rateAsDouble);
+  }
+
+  public Double calculateExchange(String from, String to, Number amount,
+                                  OperationMode operationMode, Number customRate) {
+    validateRequiredParameters(List.of("from", "to", "amount"), Arrays.asList(from, to, amount));
+    Number rate = customRate == null ? getRateFactor(from, to) : customRate;
+    log.debug("calculateExchange:: Calculating exchange exchangeRate, currency from={}, to={}, "
+      + "amount={}, exchangeRate={}, operationMode={}", from, to, amount, rate, operationMode);
+    BigDecimal bdAmount = new BigDecimal(amount.toString());
+    BigDecimal bdRate = new BigDecimal(rate.toString());
+    BigDecimal newAmount;
+    if (operationMode == OperationMode.DIVIDE) {
+      newAmount = bdAmount.divide(bdRate, 4, RoundingMode.HALF_EVEN);
+    } else {
+      newAmount = bdAmount.multiply(bdRate);
+    }
+    Double result = Money.of(newAmount, to)
+      .with(Monetary.getDefaultRounding())
+      .getNumber()
+      .doubleValueExact();
+    log.debug("calculateExchange:: result is {}", result);
+    return result;
+  }
+
+  private Number getRateFactor(String from, String to) {
     try {
-      var exchangeRate = MonetaryConversions.getExchangeRateProvider(IDENTITY, ECB)
+      return MonetaryConversions.getExchangeRateProvider(IDENTITY, ECB)
         .getExchangeRate(from, to)
-        .getFactor()
-        .doubleValue();
-      log.debug("getExchangeRate:: Fetched exchange rate={}", exchangeRate);
-      return new ExchangeRate().withFrom(from)
-        .withTo(to)
-        .withExchangeRate(exchangeRate);
+        .getFactor();
     } catch (CurrencyConversionException e) {
       var errors = List.of(ErrorCodes.CANNOT_CONVERT_AMOUNT_INVALID_CURRENCY.toError()
         .withParameters(List.of(
@@ -53,21 +84,11 @@ public class ExchangeHelper extends AbstractHelper {
     }
   }
 
-  public Double calculateExchange(String from, String to, Number amount,
-                                  ExchangeRate.OperationMode operationMode, Number customRate) {
-    var initialAmount = Money.of(amount, from);
-    var exchangeRate = customRate == null ? getExchangeRate(from, to).getExchangeRate() : customRate;
-    log.debug("calculateExchange:: Calculating exchange exchangeRate, currency from={}, to={}, "
-      + "amount={}, exchangeRate={}, operationMode={}", from, to, amount, exchangeRate, operationMode);
-    if (operationMode == ExchangeRate.OperationMode.DIVIDE) {
-      return initialAmount.divide(exchangeRate)
-        .with(Monetary.getDefaultRounding())
-        .getNumber()
-        .doubleValueExact();
+  private void validateRequiredParameters(List<String> names, List<Object> values) {
+    for (int i=0; i<names.size(); i++) {
+      if (values.get(i) == null) {
+        throw new HttpException(422, String.format("Missing required parameter: %s", names.get(i)));
+      }
     }
-    return initialAmount.multiply(exchangeRate)
-      .with(Monetary.getDefaultRounding())
-      .getNumber()
-      .doubleValueExact();
   }
 }

--- a/src/main/java/org/folio/rest/helper/ExchangeHelper.java
+++ b/src/main/java/org/folio/rest/helper/ExchangeHelper.java
@@ -1,5 +1,9 @@
 package org.folio.rest.helper;
 
+import static java.math.MathContext.DECIMAL64;
+import static org.folio.HttpStatus.HTTP_BAD_REQUEST;
+import static org.folio.HttpStatus.HTTP_NOT_FOUND;
+import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.javamoney.moneta.convert.ExchangeRateType.ECB;
 import static org.javamoney.moneta.convert.ExchangeRateType.IDENTITY;
 
@@ -9,7 +13,6 @@ import javax.money.convert.MonetaryConversions;
 
 import io.vertx.core.Context;
 import lombok.extern.log4j.Log4j2;
-import org.folio.HttpStatus;
 import org.folio.rest.exception.HttpException;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ExchangeRate;
@@ -19,15 +22,11 @@ import org.folio.rest.util.ErrorCodes;
 import org.javamoney.moneta.Money;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.List;
 
 @Log4j2
 public class ExchangeHelper extends AbstractHelper {
-
-  private static final String FROM = "from";
-  private static final String TO = "to";
 
   public ExchangeHelper(Context ctx) {
     super(ctx);
@@ -54,7 +53,7 @@ public class ExchangeHelper extends AbstractHelper {
     BigDecimal bdRate = new BigDecimal(rate.toString());
     BigDecimal newAmount;
     if (operationMode == OperationMode.DIVIDE) {
-      newAmount = bdAmount.divide(bdRate, 4, RoundingMode.HALF_EVEN);
+      newAmount = bdAmount.divide(bdRate, DECIMAL64);
     } else {
       newAmount = bdAmount.multiply(bdRate);
     }
@@ -74,20 +73,20 @@ public class ExchangeHelper extends AbstractHelper {
     } catch (CurrencyConversionException e) {
       var errors = List.of(ErrorCodes.CANNOT_CONVERT_AMOUNT_INVALID_CURRENCY.toError()
         .withParameters(List.of(
-          new Parameter().withKey(FROM).withValue(from),
-          new Parameter().withKey(TO).withValue(to))));
-      throw new HttpException(HttpStatus.HTTP_NOT_FOUND.toInt(),
+          new Parameter().withKey("from").withValue(from),
+          new Parameter().withKey("to").withValue(to))));
+      throw new HttpException(HTTP_NOT_FOUND.toInt(),
         new Errors().withErrors(errors).withTotalRecords(errors.size()));
     } catch (Exception e) {
       log.error("Error while retrieving exchange rate", e);
-      throw new HttpException(HttpStatus.HTTP_BAD_REQUEST.toInt(), e.getMessage());
+      throw new HttpException(HTTP_BAD_REQUEST.toInt(), e.getMessage());
     }
   }
 
   private void validateRequiredParameters(List<String> names, List<Object> values) {
-    for (int i=0; i<names.size(); i++) {
+    for (int i = 0; i < names.size(); i++) {
       if (values.get(i) == null) {
-        throw new HttpException(422, String.format("Missing required parameter: %s", names.get(i)));
+        throw new HttpException(HTTP_UNPROCESSABLE_ENTITY.toInt(), String.format("Missing required parameter: %s", names.get(i)));
       }
     }
   }

--- a/src/main/java/org/folio/rest/impl/ExchangeApi.java
+++ b/src/main/java/org/folio/rest/impl/ExchangeApi.java
@@ -40,6 +40,7 @@ public class ExchangeApi extends BaseApi implements FinanceExchangeRate, Finance
   }
 
   @Override
+  @Validate
   public void getFinanceCalculateExchange(String from, String to, Number amount, Number exchangeRate, boolean manual, String operationMode,
                                           Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
     var requestContext = new RequestContext(context, okapiHeaders);

--- a/src/test/java/org/folio/rest/impl/ExchangeTest.java
+++ b/src/test/java/org/folio/rest/impl/ExchangeTest.java
@@ -46,6 +46,7 @@ public class ExchangeTest {
   private static final String CALCULATE_EXCHANGE_BATCH_PATH = "finance/calculate-exchange-batch";
   private static final String VALID_REQUEST_FOR_CALCULATE_EXCHANGE = "?from=USD&to=EUR&amount=100.0";
   private static final String VALID_REQUEST_WITH_CUSTOM_RATE_FOR_CALCULATE_EXCHANGE = "?from=EUR&to=USD&amount=100.0&rate=1.08";
+  private static final String CURRENCIES_USING_DIFFERENT_DECIMALS = "?from=JPY&to=USD&amount=1000&rate=0.00719";
   private static final String SAME_CURRENCIES_FOR_CALCULATE_EXCHANGE = "?from=USD&to=USD&amount=100.0";
   private static final String NON_EXISTENT_CURRENCY_FOR_CALCULATE_EXCHANGE = "?from=ABC&to=EUR&amount=100.0";
   private static final String MISSING_FROM_FOR_CALCULATE_EXCHANGE = "?to=EUR&amount=100.0";
@@ -101,19 +102,19 @@ public class ExchangeTest {
   @Test
   void getExchangeRateMissingParameters() {
     logger.info("=== Test get exchange rate missing query parameters: BAD_REQUEST ===");
-    verifyGet(EXCHANGE_RATE_PATH, "", 400);
+    verifyGet(EXCHANGE_RATE_PATH, "", 422);
   }
 
   @Test
   void getExchangeRateMissingFromParameter() {
     logger.info("=== Test get exchange rate missing FROM parameter: BAD_REQUEST ===");
-    verifyGet(EXCHANGE_RATE_PATH + MISSING_FROM, "", 400);
+    verifyGet(EXCHANGE_RATE_PATH + MISSING_FROM, "", 422);
   }
 
   @Test
   void getExchangeRateMissingToParameter() {
     logger.info("=== Test get exchange rate missing TO parameter: BAD_REQUEST ===");
-    verifyGet(EXCHANGE_RATE_PATH + MISSING_TO, "", 400);
+    verifyGet(EXCHANGE_RATE_PATH + MISSING_TO, "", 422);
   }
 
   @Test
@@ -146,6 +147,13 @@ public class ExchangeTest {
   }
 
   @Test
+  void calculateExchangeForDifferentDecimals() {
+    logger.info("=== Test exchange calculation with currencies using a different number of decimals: Success ===");
+    var exchangeCalculation = verifyGet(CALCULATE_EXCHANGE_PATH + CURRENCIES_USING_DIFFERENT_DECIMALS, APPLICATION_JSON, 200).as(Double.class);
+    assertThat(7.19, equalTo(exchangeCalculation));
+  }
+
+  @Test
   void calculateExchangeForSameCurrencies() {
     logger.info("=== Test exchange calculation for same currency codes: Success, Amount=100.0 ===");
     var exchangeCalculation = verifyGet(CALCULATE_EXCHANGE_PATH + SAME_CURRENCIES_FOR_CALCULATE_EXCHANGE, APPLICATION_JSON, 200).as(Double.class);
@@ -155,37 +163,37 @@ public class ExchangeTest {
   @Test
   void calculateExchangeForNonexistentCurrency() {
     logger.info("=== Test exchange calculation for non-existent currency code: BAD_REQUEST ===");
-    verifyGet(CALCULATE_EXCHANGE_PATH + NON_EXISTENT_CURRENCY_FOR_CALCULATE_EXCHANGE, "", 500);
+    verifyGet(CALCULATE_EXCHANGE_PATH + NON_EXISTENT_CURRENCY_FOR_CALCULATE_EXCHANGE, "", 400);
   }
 
   @Test
   void calculateExchangeMissingParameters() {
     logger.info("=== Test exchange calculation missing query parameters: BAD_REQUEST ===");
-    verifyGet(CALCULATE_EXCHANGE_PATH, "", 500);
+    verifyGet(CALCULATE_EXCHANGE_PATH, "", 422);
   }
 
   @Test
   void calculateExchangeMissingSourceCurrencyParameter() {
     logger.info("=== Test exchange calculation missing FROM parameter: BAD_REQUEST ===");
-    verifyGet(CALCULATE_EXCHANGE_PATH + MISSING_FROM_FOR_CALCULATE_EXCHANGE, "", 500);
+    verifyGet(CALCULATE_EXCHANGE_PATH + MISSING_FROM_FOR_CALCULATE_EXCHANGE, "", 422);
   }
 
   @Test
   void calculateExchangeMissingTargetCurrencyParameter() {
     logger.info("=== Test exchange calculation missing TO parameter: BAD_REQUEST ===");
-    verifyGet(CALCULATE_EXCHANGE_PATH + MISSING_TO_FOR_CALCULATE_EXCHANGE, "", 400);
+    verifyGet(CALCULATE_EXCHANGE_PATH + MISSING_TO_FOR_CALCULATE_EXCHANGE, "", 422);
   }
 
   @Test
   void calculateExchangeMissingAmountParameter() {
     logger.info("=== Test exchange calculation missing AMOUNT parameter: BAD_REQUEST ===");
-    verifyGet(CALCULATE_EXCHANGE_PATH + MISSING_AMOUNT, "", 500);
+    verifyGet(CALCULATE_EXCHANGE_PATH + MISSING_AMOUNT, "", 422);
   }
 
   @Test
   void calculateExchangeInvalidCurrencyCode() {
     logger.info("=== Test exchange calculation for invalid currency code: BAD_REQUEST ===");
-    verifyGet(CALCULATE_EXCHANGE_PATH + INVALID_CURRENCY_FOR_CALCULATE_EXCHANGE, "", 500);
+    verifyGet(CALCULATE_EXCHANGE_PATH + INVALID_CURRENCY_FOR_CALCULATE_EXCHANGE, "", 400);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODFIN-460](https://folio-org.atlassian.net/browse/MODFIN-460) - Exchange rate conversion gives wrong number of decimals

## Approach
- Fixed issue with the number of decimals when converting with a custom exchange rate
- Using BigDecimal instead of Double for internal calculations (such as when using an exchange rate)
- Fixed validation (there were 500 internal errors for missing parameters)

---

## Pre-Review Checklist

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
