### PR TITLE
MODFIN-460. Use rounding for custom exchange rate provider as well

### DIFF
--- a/src/main/java/org/folio/services/exchange/ExchangeService.java
+++ b/src/main/java/org/folio/services/exchange/ExchangeService.java
@@ -25,6 +25,7 @@ import org.javamoney.moneta.Money;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.money.Monetary;
 import javax.money.convert.ConversionQueryBuilder;
 import java.math.BigDecimal;
 import java.net.http.HttpClient;
@@ -113,6 +114,7 @@ public class ExchangeService {
       .build();
     return Money.of(amount, from)
       .with(provider.getCurrencyConversion(query))
+      .with(Monetary.getDefaultRounding())
       .getNumber()
       .doubleValueExact();
   }

--- a/src/test/java/org/folio/services/exchange/ExchangeServiceTest.java
+++ b/src/test/java/org/folio/services/exchange/ExchangeServiceTest.java
@@ -127,7 +127,7 @@ public class ExchangeServiceTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"TREASURY_GOV,0d,false,9.61d", "TREASURY_GOV,10d,true,100d", "CURRENCYAPI_COM,0d,false,9.052401139"})
+  @CsvSource({"TREASURY_GOV,0d,false,9.61d", "TREASURY_GOV,10d,true,100d", "CURRENCYAPI_COM,0d,false,9.05d"})
   void testCalculateExchangeRateUsingCustomJsonExchangeRateProvider(ExchangeRateSource.ProviderType providerType, double exchangeRate, boolean manual,
                                                                     double expectedAmount, VertxTestContext testContext) throws IOException, InterruptedException {
     when(httpResponse.statusCode()).thenReturn(HttpStatus.HTTP_OK.toInt());


### PR DESCRIPTION
### **Purpose**
Follow up PR for https://folio-org.atlassian.net/browse/MODFIN-460 to use default rounding as for common exchange rate calculations

### **Approach**
_Provide a brief technical summary of the changes._

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
